### PR TITLE
Add dedicated ticket pool value and sdiff endpoints.

### DIFF
--- a/apimiddleware.go
+++ b/apimiddleware.go
@@ -77,7 +77,7 @@ func BlockIndex0PathCtx(next http.Handler) http.Handler {
 		pathIdxStr := chi.URLParam(r, "idx0")
 		idx, err := strconv.Atoi(pathIdxStr)
 		if err != nil {
-			apiLog.Infof("No/invalid idx value (int64): %v", err)
+			apiLog.Infof("No/invalid idx0 value (int64): %v", err)
 			http.NotFound(w, r)
 			//http.Error(w, http.StatusText(404), 404)
 			return

--- a/dcrdataapi/apitypes.go
+++ b/dcrdataapi/apitypes.go
@@ -23,6 +23,13 @@ type TicketPoolInfo struct {
 	ValAvg float64 `json:"valavg"`
 }
 
+type TicketPoolValsAndSizes struct {
+	StartHeight uint32    `json:"start_height"`
+	EndHeight   uint32    `json:"end_height"`
+	Value       []float64 `json:"value"`
+	Size        []float64 `json:"size"`
+}
+
 type BlockDataBasic struct {
 	Height     uint32  `json:"height"`
 	Size       uint32  `json:"size"`

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -149,6 +149,42 @@ func (db *wiredDB) GetBestBlockSummary() *apitypes.BlockDataBasic {
 	return blockSummary
 }
 
+func (db *wiredDB) GetPoolInfo(idx int) *apitypes.TicketPoolInfo {
+	ticketPoolInfo, err := db.RetrievePoolInfo(int64(idx))
+	if err != nil {
+		log.Errorf("Unable to retrieve ticket pool info: %v", err)
+		return nil
+	}
+	return ticketPoolInfo
+}
+
+func (db *wiredDB) GetPoolInfoRange(idx0, idx1 int) []apitypes.TicketPoolInfo {
+	ticketPoolInfos, err := db.RetrievePoolInfoRange(int64(idx0), int64(idx1))
+	if err != nil {
+		log.Errorf("Unable to retrieve ticket pool info range: %v", err)
+		return nil
+	}
+	return ticketPoolInfos
+}
+
+func (db *wiredDB) GetSDiff(idx int) float64 {
+	sdiff, err := db.RetrieveSDiff(int64(idx))
+	if err != nil {
+		log.Errorf("Unable to retrieve stake difficulty: %v", err)
+		return -1
+	}
+	return sdiff
+}
+
+func (db *wiredDB) GetSDiffRange(idx0, idx1 int) []float64 {
+	sdiffs, err := db.RetrieveSDiffRange(int64(idx0), int64(idx1))
+	if err != nil {
+		log.Errorf("Unable to retrieve stake difficulty range: %v", err)
+		return nil
+	}
+	return sdiffs
+}
+
 func (db *wiredDB) GetMempoolSSTxSummary() *apitypes.MempoolTicketFeeInfo {
 	_, feeInfo := db.MPC.GetFeeInfoExtra()
 	return feeInfo

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -167,6 +167,15 @@ func (db *wiredDB) GetPoolInfoRange(idx0, idx1 int) []apitypes.TicketPoolInfo {
 	return ticketPoolInfos
 }
 
+func (db *wiredDB) GetPoolValAndSizeRange(idx0, idx1 int) ([]float64, []float64) {
+	poolvals, poolsizes, err := db.RetrievePoolValAndSizeRange(int64(idx0), int64(idx1))
+	if err != nil {
+		log.Errorf("Unable to retrieve ticket value and size range: %v", err)
+		return nil, nil
+	}
+	return poolvals, poolsizes
+}
+
 func (db *wiredDB) GetSDiff(idx int) float64 {
 	sdiff, err := db.RetrieveSDiff(int64(idx))
 	if err != nil {


### PR DESCRIPTION
Separate /stake into /stake/pool and /stake/diff for ticket pool info and sdiff, resp.  Each have ./b/:ind and ./r/:ind0/:ind endpoints for values at a given block and on a range, resp.

TODO: log warning when sql result is shorter (or longer) than expected for range queries.

Begins to address https://github.com/dcrdata/dcrdata/issues/34, items 1 - 3.  The results need caching, but now there is are at least array returns for sdiff and ticket pool info.

Also continues to address https://github.com/dcrdata/dcrdata/issues/20, which is an open ended issue to add new endpoints for 0.1.0.