### PR TITLE
Fix rewind - Stake node disconnect needs to be followed by DB update

### DIFF
--- a/dcrsqlite/sync.go
+++ b/dcrsqlite/sync.go
@@ -304,6 +304,7 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 				return err
 			}
 			bestNodeHeight = int64(bestNode.Height())
+			log.Infof("Stake db now at height %d.", bestNodeHeight)
 		}
 	}
 	if startHeight < -1 {


### PR DESCRIPTION
When a node is disconnected, the on-disk database needs to be updated to reflect the change.  Fixes rewind.