### PR TITLE
Keep stake DB updated and avoid rewind on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ LOG
 MANIFEST-*
 ffldb_stake/
 *.pprof
+testnet/

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -203,7 +203,10 @@ func (t *blockDataCollector) Collect(noTicketPool bool) (*BlockData, error) {
 	// estimatestakediff
 	estStakeDiff, err := t.dcrdChainSvr.EstimateStakeDiff(nil)
 	if err != nil {
-		return nil, err
+		log.Warn("estimatestakediff is broken: ", err)
+		estStakeDiff = &dcrjson.EstimateStakeDiffResult{}
+		err = nil
+		//return nil, err
 	}
 
 	// Output

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -4,13 +4,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
 	"strconv"
 	"sync"
 	"time"
 
 	apitypes "github.com/dcrdata/dcrdata/dcrdataapi"
-	"github.com/decred/dcrd/blockchain"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson"
@@ -219,24 +217,4 @@ func (t *blockDataCollector) Collect(noTicketPool bool) (*BlockData, error) {
 	}
 
 	return blockdata, err
-}
-
-// GetDifficultyRatio returns the proof-of-work difficulty as a multiple of the
-// minimum difficulty using the passed bits field from the header of a block.
-func GetDifficultyRatio(bits uint32, params *chaincfg.Params) float64 {
-	// The minimum difficulty is the max possible proof-of-work limit bits
-	// converted back to a number.  Note this is not the same as the proof of
-	// work limit directly because the block difficulty is encoded in a block
-	// with the compact form which loses precision.
-	max := blockchain.CompactToBig(params.PowLimitBits)
-	target := blockchain.CompactToBig(bits)
-
-	difficulty := new(big.Rat).SetFrac(max, target)
-	outString := difficulty.FloatString(8)
-	diff, err := strconv.ParseFloat(outString, 64)
-	if err != nil {
-		log.Errorf("Cannot get difficulty: %v", err)
-		return 0
-	}
-	return diff
 }

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 package blockdata
 
 import (

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -176,7 +176,7 @@ func (t *blockDataCollector) Collect(noTicketPool bool) (*BlockData, error) {
 	// instead:
 	blockHeaderResults := dcrjson.GetBlockHeaderVerboseResult{
 		Hash:          bestBlockHash.String(),
-		Confirmations: uint64(1),
+		Confirmations: int64(1),
 		Version:       blockHeader.Version,
 		PreviousHash:  blockHeader.PrevBlock.String(),
 		MerkleRoot:    blockHeader.MerkleRoot.String(),

--- a/blockdata/chainmonitor.go
+++ b/blockdata/chainmonitor.go
@@ -172,7 +172,7 @@ out:
 			}
 
 			newHeight, oldHeight := reorgData.NewChainHeight, reorgData.OldChainHeight
-			newHash, oldHash := reorgData.NewChainHeight, reorgData.OldChainHeight
+			newHash, oldHash := reorgData.NewChainHead, reorgData.OldChainHead
 
 			p.reorgLock.Lock()
 			if p.reorganizing {

--- a/blockdata/chainmonitor.go
+++ b/blockdata/chainmonitor.go
@@ -11,6 +11,14 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 )
 
+// ReorgData contains the information from a reoranization notification
+type ReorgData struct {
+	OldChainHead   chainhash.Hash
+	OldChainHeight int32
+	NewChainHead   chainhash.Hash
+	NewChainHeight int32
+}
+
 // for getblock, ticketfeeinfo, estimatestakediff, etc.
 type chainMonitor struct {
 	collector       *blockDataCollector
@@ -21,6 +29,13 @@ type chainMonitor struct {
 	watchaddrs      map[string]txhelpers.TxAction
 	blockChan       chan *chainhash.Hash
 	recvTxBlockChan chan *txhelpers.BlockWatchedTx
+	reorgChan       chan *ReorgData
+
+	// reorg handling
+	reorgLock    sync.Mutex
+	reorgData    *ReorgData
+	sideChain    []chainhash.Hash
+	reorganizing bool
 }
 
 // NewChainMonitor creates a new chainMonitor
@@ -28,7 +43,8 @@ func NewChainMonitor(collector *blockDataCollector,
 	savers []BlockDataSaver,
 	quit chan struct{}, wg *sync.WaitGroup, noPoolValue bool,
 	addrs map[string]txhelpers.TxAction, blockChan chan *chainhash.Hash,
-	recvTxBlockChan chan *txhelpers.BlockWatchedTx) *chainMonitor {
+	recvTxBlockChan chan *txhelpers.BlockWatchedTx,
+	reorgChan chan *ReorgData) *chainMonitor {
 	return &chainMonitor{
 		collector:       collector,
 		dataSavers:      savers,
@@ -38,6 +54,7 @@ func NewChainMonitor(collector *blockDataCollector,
 		watchaddrs:      addrs,
 		blockChan:       blockChan,
 		recvTxBlockChan: recvTxBlockChan,
+		reorgChan:       reorgChan,
 	}
 }
 
@@ -54,6 +71,30 @@ out:
 				log.Warnf("Block connected channel closed.")
 				break out
 			}
+
+			// If reorganizing, the block will first go to a side chain
+			p.reorgLock.Lock()
+			reorg, reorgData := p.reorganizing, p.reorgData
+			p.reorgLock.Unlock()
+
+			if reorg {
+				p.sideChain = append(p.sideChain, *hash)
+				log.Infof("Adding block %v to sidechain", *hash)
+
+				// Just append to side chain until the new main chain tip block is reached
+				if !reorgData.NewChainHead.IsEqual(hash) {
+					break keepon
+				}
+
+				// Reorg is complete
+				p.sideChain = nil
+				p.reorgLock.Lock()
+				p.reorganizing = false
+				p.reorgLock.Unlock()
+				log.Infof("Reorganization to block %v (height %d) complete",
+					p.reorgData.NewChainHead, p.reorgData.NewChainHeight)
+			}
+
 			block, _ := p.collector.dcrdChainSvr.GetBlock(hash)
 			height := block.Height()
 			log.Infof("Block height %v connected", height)
@@ -108,10 +149,54 @@ out:
 
 		case _, ok := <-p.quit:
 			if !ok {
-				log.Debugf("Got quit signal. Exiting block connected handler for BLOCK monitor.")
+				log.Debugf("Got quit signal. Exiting block connected handler.")
 				break out
 			}
 		}
 	}
 
+}
+
+// ReorgHandler receives notification of a chain reorganization and initiates a
+// corresponding update of the SQL db keeping the main chain data.
+func (p *chainMonitor) ReorgHandler() {
+	defer p.wg.Done()
+out:
+	for {
+	keepon:
+		select {
+		case reorgData, ok := <-p.reorgChan:
+			if !ok {
+				log.Warnf("Reorg channel closed.")
+				break out
+			}
+
+			newHeight, oldHeight := reorgData.NewChainHeight, reorgData.OldChainHeight
+			newHash, oldHash := reorgData.NewChainHeight, reorgData.OldChainHeight
+
+			p.reorgLock.Lock()
+			if p.reorganizing {
+				p.reorgLock.Unlock()
+				log.Errorf("Reorg notified for chain tip %v (height %v), but already "+
+					"processing a reorg to block %v", newHash, newHeight,
+					p.reorgData.NewChainHead)
+				break keepon
+			}
+
+			p.reorganizing = true
+			p.reorgData = reorgData
+			p.reorgLock.Unlock()
+
+			log.Infof("Reorganize started. NEW head block %v at height %d.",
+				newHash, newHeight)
+			log.Infof("Reorganize started. OLD head block %v at height %d.",
+				oldHash, oldHeight)
+
+		case _, ok := <-p.quit:
+			if !ok {
+				log.Debugf("Got quit signal. Exiting reorg notification handler.")
+				break out
+			}
+		}
+	}
 }

--- a/blockdata/chainmonitor.go
+++ b/blockdata/chainmonitor.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 package blockdata
 
 import (

--- a/blockdata/datasaver.go
+++ b/blockdata/datasaver.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 // Interface for saving/storing BlockData.
 // Create a BlockDataSaver by implementing Store(*BlockData).
 

--- a/cmd/rebuilddb/config.go
+++ b/cmd/rebuilddb/config.go
@@ -200,7 +200,7 @@ func loadConfig() (*config, error) {
 	// Set the host names and ports to the default if the
 	// user does not specify them.
 	if cfg.DcrdServ == "" {
-		cfg.DcrdServ = defaultHost + ":" + activeNet.RPCClientPort
+		cfg.DcrdServ = defaultHost + ":" + activeNet.JSONRPCClientPort
 	}
 
 	// Append the network type to the log directory so it is "namespaced"

--- a/cmd/rebuilddb/config.go
+++ b/cmd/rebuilddb/config.go
@@ -179,8 +179,8 @@ func loadConfig() (*config, error) {
 	activeNet = &netparams.MainNetParams
 	activeChain = &chaincfg.MainNetParams
 	if cfg.TestNet {
-		activeNet = &netparams.TestNetParams
-		activeChain = &chaincfg.TestNetParams
+		activeNet = &netparams.TestNet2Params
+		activeChain = &chaincfg.TestNet2Params
 		numNets++
 	}
 	if cfg.SimNet {

--- a/cmd/rebuilddb/rebuilddb.go
+++ b/cmd/rebuilddb/rebuilddb.go
@@ -81,7 +81,8 @@ func mainCore() int {
 	dcrsqlite.UseLogger(btclogger)
 	dbInfo := dcrsqlite.DBInfo{FileName: cfg.DBFileName}
 	//sqliteDB, err := dcrsqlite.InitDB(&dbInfo)
-	sqliteDB, err := dcrsqlite.InitWiredDB(&dbInfo, nil, client, activeChain)
+	sqliteDB, cleanupDB, err := dcrsqlite.InitWiredDB(&dbInfo, nil, client, activeChain)
+	defer cleanupDB()
 	if err != nil {
 		log.Errorf("Unable to initialize SQLite database: %v", err)
 	}

--- a/config.go
+++ b/config.go
@@ -300,8 +300,8 @@ func loadConfig() (*config, error) {
 	activeNet = &netparams.MainNetParams
 	activeChain = &chaincfg.MainNetParams
 	if cfg.TestNet {
-		activeNet = &netparams.TestNetParams
-		activeChain = &chaincfg.TestNetParams
+		activeNet = &netparams.TestNet2Params
+		activeChain = &chaincfg.TestNet2Params
 		numNets++
 	}
 	if cfg.SimNet {

--- a/config.go
+++ b/config.go
@@ -321,7 +321,7 @@ func loadConfig() (*config, error) {
 	// Set the host names and ports to the default if the
 	// user does not specify them.
 	if cfg.DcrdServ == "" {
-		cfg.DcrdServ = defaultHost + ":" + activeNet.RPCClientPort
+		cfg.DcrdServ = defaultHost + ":" + activeNet.JSONRPCClientPort
 	}
 
 	// Put comma-separated comamnd line aguments into slice of strings

--- a/dcrdataapi/apitypes.go
+++ b/dcrdataapi/apitypes.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 package dcrdataapi
 
 import (

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -59,9 +59,9 @@ func InitWiredDB(dbInfo *DBInfo, statusC chan uint32, cl *dcrrpcclient.Client, p
 	return wDB, cleanup, nil
 }
 
-func (db *wiredDB) NewChainMonitor(quit chan struct{}, wg *sync.WaitGroup,
-	blockChan chan *chainhash.Hash) *stakedb.ChainMonitor {
-	return db.sDB.NewChainMonitor(quit, wg, blockChan)
+func (db *wiredDB) NewStakeDBChainMonitor(quit chan struct{}, wg *sync.WaitGroup,
+	blockChan chan *chainhash.Hash, reorgChan chan *stakedb.ReorgData) *stakedb.ChainMonitor {
+	return db.sDB.NewChainMonitor(quit, wg, blockChan, reorgChan)
 }
 
 func (db *wiredDB) SyncDB(wg *sync.WaitGroup, quit chan struct{}) error {

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dcrdata/dcrdata/rpcutils"
 	"github.com/dcrdata/dcrdata/stakedb"
 	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrrpcclient"
 )
@@ -53,6 +54,11 @@ func InitWiredDB(dbInfo *DBInfo, statusC chan uint32, cl *dcrrpcclient.Client, p
 
 	wDB, cleanup := newWiredDB(db, statusC, cl, p)
 	return wDB, cleanup, nil
+}
+
+func (db *wiredDB) NewChainMonitor(quit chan struct{}, wg *sync.WaitGroup,
+	blockChan chan *chainhash.Hash) *stakedb.ChainMonitor {
+	return db.sDB.NewChainMonitor(quit, wg, blockChan)
 }
 
 func (db *wiredDB) SyncDB(wg *sync.WaitGroup, quit chan struct{}) error {

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -7,6 +7,7 @@ import (
 	apitypes "github.com/dcrdata/dcrdata/dcrdataapi"
 	"github.com/dcrdata/dcrdata/mempool"
 	"github.com/dcrdata/dcrdata/rpcutils"
+	"github.com/dcrdata/dcrdata/stakedb"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrrpcclient"
@@ -19,28 +20,39 @@ type wiredDB struct {
 	MPC    *mempool.MempoolDataCache
 	client *dcrrpcclient.Client
 	params *chaincfg.Params
+	sDB    *stakedb.StakeDatabase
 }
 
-func NewWiredDB(db *sql.DB, statusC chan uint32, cl *dcrrpcclient.Client, p *chaincfg.Params) wiredDB {
-	return wiredDB{
-		DBDataSaver: &DBDataSaver{NewDB(db), statusC},
+func newWiredDB(DB *DB, statusC chan uint32, cl *dcrrpcclient.Client, p *chaincfg.Params) (wiredDB, func() error) {
+	wDB := wiredDB{
+		DBDataSaver: &DBDataSaver{DB, statusC},
 		MPC:         new(mempool.MempoolDataCache),
 		client:      cl,
 		params:      p,
 	}
+
+	//err := wDB.openStakeDB()
+	var err error
+	wDB.sDB, err = stakedb.NewStakeDatabase(cl, p)
+	if err != nil {
+		log.Error("Unable to create stake DB: ", err)
+		return wDB, func() error { return nil }
+	}
+	return wDB, wDB.sDB.StakeDB.Close
 }
 
-func InitWiredDB(dbInfo *DBInfo, statusC chan uint32, cl *dcrrpcclient.Client, p *chaincfg.Params) (wiredDB, error) {
+func NewWiredDB(db *sql.DB, statusC chan uint32, cl *dcrrpcclient.Client, p *chaincfg.Params) (wiredDB, func() error) {
+	return newWiredDB(NewDB(db), statusC, cl, p)
+}
+
+func InitWiredDB(dbInfo *DBInfo, statusC chan uint32, cl *dcrrpcclient.Client, p *chaincfg.Params) (wiredDB, func() error, error) {
 	db, err := InitDB(dbInfo)
 	if err != nil {
-		return wiredDB{}, err
+		return wiredDB{}, func() error { return nil }, err
 	}
-	return wiredDB{
-		DBDataSaver: &DBDataSaver{db, statusC},
-		MPC:         new(mempool.MempoolDataCache),
-		client:      cl,
-		params:      p,
-	}, nil
+
+	wDB, cleanup := newWiredDB(db, statusC, cl, p)
+	return wDB, cleanup, nil
 }
 
 func (db *wiredDB) SyncDB(wg *sync.WaitGroup, quit chan struct{}) error {

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 package dcrsqlite
 
 import (

--- a/dcrsqlite/chainmonitor.go
+++ b/dcrsqlite/chainmonitor.go
@@ -154,7 +154,7 @@ out:
 
 		case _, ok := <-p.quit:
 			if !ok {
-				log.Debugf("Got quit signal. Exiting block connected handler for BLOCK monitor.")
+				log.Debugf("Got quit signal. Exiting block connected handler for REORG monitor.")
 				break out
 			}
 		}

--- a/dcrsqlite/chainmonitor.go
+++ b/dcrsqlite/chainmonitor.go
@@ -96,7 +96,7 @@ out:
 
 		case _, ok := <-p.quit:
 			if !ok {
-				log.Debugf("Got quit signal. Exiting block connected handler for BLOCK monitor.")
+				log.Debugf("Got quit signal. Exiting block connected handler.")
 				break out
 			}
 		}
@@ -118,7 +118,7 @@ func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 }
 
 // ReorgHandler receives notification of a chain reorganization and initiates a
-// corresponding reorganization of the stakedb.StakeDatabase.
+// corresponding update of the SQL db keeping the main chain data.
 func (p *ChainMonitor) ReorgHandler() {
 	defer p.wg.Done()
 out:
@@ -154,7 +154,7 @@ out:
 
 		case _, ok := <-p.quit:
 			if !ok {
-				log.Debugf("Got quit signal. Exiting block connected handler for REORG monitor.")
+				log.Debugf("Got quit signal. Exiting reorg notification handler.")
 				break out
 			}
 		}

--- a/dcrsqlite/chainmonitor.go
+++ b/dcrsqlite/chainmonitor.go
@@ -132,7 +132,7 @@ out:
 			}
 
 			newHeight, oldHeight := reorgData.NewChainHeight, reorgData.OldChainHeight
-			newHash, oldHash := reorgData.NewChainHeight, reorgData.OldChainHeight
+			newHash, oldHash := reorgData.NewChainHead, reorgData.OldChainHead
 
 			p.reorgLock.Lock()
 			if p.reorganizing {

--- a/dcrsqlite/sqlite.go
+++ b/dcrsqlite/sqlite.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 package dcrsqlite
 
 import (

--- a/dcrsqlite/sync.go
+++ b/dcrsqlite/sync.go
@@ -1,21 +1,15 @@
 package dcrsqlite
 
 import (
-	"encoding/binary"
 	"fmt"
 	"math"
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/dcrdata/dcrdata/blockdata"
 	apitypes "github.com/dcrdata/dcrdata/dcrdataapi"
 	"github.com/dcrdata/dcrdata/txhelpers"
-	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrd/database"
 	"github.com/decred/dcrutil"
-	"github.com/oleiade/lane"
 )
 
 const (
@@ -192,57 +186,10 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 	bestStakeHeight := db.GetStakeInfoHeight()
 
 	// Create a new database to store the accepted stake node data into.
-	dbName := DefaultStakeDbName
-	stakeDB, err := database.Open(dbType, dbName, db.params.Net)
-	if err != nil {
-		_ = os.RemoveAll(dbName)
-		stakeDB, err = database.Create(dbType, dbName, db.params.Net)
-		if err != nil {
-			return fmt.Errorf("error creating db: %v", err)
-		}
+	if db.sDB == nil || db.sDB.BestNode == nil {
+		return fmt.Errorf("Cannot resync without the stake DB")
 	}
-	//defer os.RemoveAll(dbName)
-	defer stakeDB.Close()
-
-	// Load the best block from stake db
-	var bestNode *stake.Node
-	var bestNodeHeight int64
-	err = stakeDB.View(func(dbTx database.Tx) error {
-		v := dbTx.Metadata().Get([]byte("stakechainstate"))
-		if v == nil {
-			return fmt.Errorf("missing key for chain state data")
-		}
-
-		var stakeDBHash chainhash.Hash
-		copy(stakeDBHash[:], v[:chainhash.HashSize])
-		offset := chainhash.HashSize
-		stakeDBHeight := binary.LittleEndian.Uint32(v[offset : offset+4])
-		bestNodeHeight = int64(stakeDBHeight)
-
-		var errLocal error
-		block, errLocal := db.client.GetBlock(&stakeDBHash)
-		if errLocal != nil {
-			return fmt.Errorf("GetBlock failed (%s): %v", stakeDBHash, errLocal)
-		}
-		header := block.MsgBlock().Header
-
-		bestNode, errLocal = stake.LoadBestNode(dbTx, stakeDBHeight,
-			stakeDBHash, header, db.params)
-		return errLocal
-	})
-	if err != nil {
-		err = stakeDB.Update(func(dbTx database.Tx) error {
-			var errLocal error
-			bestNode, errLocal = stake.InitDatabaseState(dbTx, db.params)
-			return errLocal
-		})
-		if err != nil {
-			return err
-		}
-		log.Debug("Created new stake db.")
-	} else {
-		log.Debug("Opened existing stake db.")
-	}
+	bestNodeHeight := int64(db.sDB.Height())
 
 	log.Info("Current best block (chain server): ", height)
 	log.Info("Current best block (summary DB):   ", bestBlockHeight)
@@ -278,32 +225,10 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 				return nil
 			default:
 			}
-			formerBestNode := bestNode
-			parentBlock, _, err := db.getBlock(bestNodeHeight - 1)
-			if err != nil {
+			if err = db.sDB.DisconnectBlock(); err != nil {
 				return err
 			}
-			// previous best node
-			err = stakeDB.View(func(dbTx database.Tx) error {
-				var errLocal error
-				bestNode, errLocal = bestNode.DisconnectNode(parentBlock.MsgBlock().Header, nil, nil, dbTx)
-				return errLocal
-			})
-			if err != nil {
-				return err
-			}
-			err = stakeDB.Update(func(dbTx database.Tx) error {
-				if e := stake.WriteDisconnectedBestNode(dbTx, bestNode,
-					*parentBlock.Hash(), formerBestNode.UndoData()); e != nil {
-					return fmt.Errorf("failure writing the best node: %v",
-						e.Error())
-				}
-				return nil
-			})
-			if err != nil {
-				return err
-			}
-			bestNodeHeight = int64(bestNode.Height())
+			bestNodeHeight = int64(db.sDB.Height())
 			log.Infof("Stake db now at height %d.", bestNodeHeight)
 		}
 	}
@@ -329,8 +254,6 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 
 	// a ticket treap would be nice, but a map will do for a cache
 	liveTicketCache := make(map[chainhash.Hash]int64)
-
-	blockQueue := lane.NewQueue()
 
 	var startHeight0, firstMatureHeight int64
 	if startHeight < db.params.StakeEnabledHeight {
@@ -359,14 +282,10 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 			return fmt.Errorf("GetBlock failed (%s): %v", blockhash, err)
 		}
 
-		if i >= firstMatureHeight {
-			blockQueue.Enqueue(block)
-		}
-
-		numLive := bestNode.PoolSize()
-		liveTickets := bestNode.LiveTickets()
+		numLive := db.sDB.BestNode.PoolSize()
+		liveTickets := db.sDB.BestNode.LiveTickets()
 		// TODO: winning tickets
-		//winningTickets := bestNode.Winners()
+		//winningTickets := db.sDB.BestNode.Winners()
 
 		if i%rescanLogBlockChunk == 0 || i == startHeight0 {
 			endRangeBlock := rescanLogBlockChunk * (1 + i/rescanLogBlockChunk)
@@ -395,58 +314,9 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 		}
 
 		if i > bestNodeHeight {
-			var ticketsToAdd []chainhash.Hash
-			if i >= startHeight && i >= db.params.StakeEnabledHeight {
-				//matureHeight := (i - int64(db.params.TicketMaturity))
-				if blockQueue.Size() != int(db.params.TicketMaturity)+1 {
-					panic("crap: " + strconv.Itoa(blockQueue.Size()) + " " + strconv.Itoa(int(i)))
-				}
-				maturingBlock := blockQueue.Dequeue().(*dcrutil.Block)
-				if maturingBlock.Height() != i-int64(db.params.TicketMaturity) {
-					panic("crap: " + strconv.Itoa(int(maturingBlock.Height())) + " " +
-						strconv.Itoa(int(i)-int(db.params.TicketMaturity)))
-				}
-				ticketsToAdd = txhelpers.TicketsInBlock(maturingBlock)
-				log.Tracef("Adding %02d tickets from block %d", len(ticketsToAdd),
-					maturingBlock.Height())
-			}
-
-			spentTickets := txhelpers.TicketsSpentInBlock(block)
-			for it := range spentTickets {
-				delete(liveTicketCache, spentTickets[it])
-			}
-			revokedTickets := txhelpers.RevokedTicketsInBlock(block)
-			for it := range revokedTickets {
-				delete(liveTicketCache, revokedTickets[it])
-			}
-
-			if bestNode.Height()+1 != uint32(i) {
-				panic(fmt.Sprintf("Best node height %d, trying to add %d", bestNode.Height(), i))
-			}
-
-			bestNode, err = bestNode.ConnectNode(block.MsgBlock().Header,
-				spentTickets, revokedTickets, ticketsToAdd)
-			if err != nil {
-				return fmt.Errorf("couldn't connect node %d: %v", i, err.Error())
-			}
-
-			err = stakeDB.Update(func(dbTx database.Tx) error {
-				// Write the new node to db.
-				err = stake.WriteConnectedBestNode(dbTx, bestNode, *block.Hash())
-				if err != nil {
-					return fmt.Errorf("failure writing the best node: %v",
-						err.Error())
-				}
-
-				return nil
-			})
-			if err != nil {
+			if err = db.sDB.ConnectBlock(block); err != nil {
 				return err
 			}
-		}
-
-		if blockQueue.Size() == int(db.params.TicketMaturity)+1 {
-			blockQueue.Dequeue()
 		}
 
 		if i < startHeight {

--- a/dcrsqlite/sync.go
+++ b/dcrsqlite/sync.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 package dcrsqlite
 
 import (

--- a/dcrsqlite/sync.go
+++ b/dcrsqlite/sync.go
@@ -268,11 +268,10 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 			return fmt.Errorf("GetBlock failed (%s): %v", blockhash, err)
 		}
 
-		if i != int64(db.sDB.Height()+1) {
-			panic("about to connect the wrong block")
-		}
-
 		if i > bestNodeHeight {
+			if i != int64(db.sDB.Height()+1) {
+				panic(fmt.Sprintf("about to connect the wrong block: %d, %d", i, db.sDB.Height()))
+			}
 			if err = db.sDB.ConnectBlock(block); err != nil {
 				return err
 			}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 664e7ff075f23ed044db2989e0fa71842d337b1688d17c6415bf713dbdd4116e
-updated: 2017-05-09T22:24:30.315306525-07:00
+updated: 2017-05-19T21:52:49.5799233-07:00
 imports:
 - name: github.com/btcsuite/btclog
   version: 73889fb79bd687870312b6e40effcecffbd57d30
@@ -35,7 +35,7 @@ imports:
 - name: github.com/decred/blake256
   version: a840e32d7c31fe2e0218607334cb120a683951a4
 - name: github.com/decred/dcrd
-  version: ecd27f0d4d0b6a9b6b64ee4c38eaab2c4b81e557
+  version: 3428a4011fc64efb125a5c926addefcc5dc46a40
   subpackages:
   - blockchain
   - blockchain/internal/dbnamespace
@@ -57,14 +57,14 @@ imports:
   - txscript
   - wire
 - name: github.com/decred/dcrrpcclient
-  version: d6edcb0f8f2d01fbf9169f240f73756b41423189
+  version: 7208596a68e5114e0c27d08b26c69cf38ccd1ee2
 - name: github.com/decred/dcrutil
-  version: ebd2e98736e819ac043d54439969b30144b92ced
+  version: a6bb98a643e1209e609dffa412f0561e3e4b4e50
   subpackages:
   - base58
   - hdkeychain
 - name: github.com/decred/dcrwallet
-  version: f554425c18066a374f6536e8d8bc3249a636b5dc
+  version: 9b2d1454660414635a2c5c0d81a36b11838cc702
   subpackages:
   - apperrors
   - chain
@@ -87,7 +87,7 @@ imports:
 - name: github.com/mgutz/ansi
   version: 9520e82c474b0a04dd04f8a40959027271bab992
 - name: github.com/pressly/chi
-  version: a57b1fbe2989382bdef31d3793d4a50a0e4a1d7c
+  version: 5f645ae32b572998bed8ceaf80318569ef3b69fc
   subpackages:
   - docgen
   - middleware
@@ -96,7 +96,7 @@ imports:
 - name: github.com/Sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: golang.org/x/crypto
-  version: 122d919ec1efcfb58483215da23f815853e24b81
+  version: 0fe963104e9d1877082f8fb38f816fcd97eb1d10
   subpackages:
   - nacl/secretbox
   - pbkdf2
@@ -105,11 +105,11 @@ imports:
   - salsa20/salsa
   - scrypt
 - name: golang.org/x/net
-  version: da118f7b8e5954f39d0d2130ab35d4bf0e3cb344
+  version: 513929065c19401a1c7b76ecd942f9f86a0c061b
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: 9ccfe848b9db8435a24c424abbc07a921adf1df5
+  version: a2e06a18b0d52d8cb2010e04b372a1965d8e3439
   subpackages:
   - unix
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4a4af8f934226d916845c046f14283eddcc10ca94231c0c769432b514852f0b7
-updated: 2017-03-09T00:24:05.003940423Z
+hash: 664e7ff075f23ed044db2989e0fa71842d337b1688d17c6415bf713dbdd4116e
+updated: 2017-05-09T22:24:30.315306525-07:00
 imports:
 - name: github.com/btcsuite/btclog
   version: 73889fb79bd687870312b6e40effcecffbd57d30
@@ -9,10 +9,6 @@ imports:
   version: 4720035b7bfd2a9bb130b1c184f8bbe41b6f0d0f
   subpackages:
   - socks
-- name: github.com/btcsuite/golangcrypto
-  version: 53f62d9b43e87a6c56975cf862af7edf33a8d0df
-  subpackages:
-  - ripemd160
 - name: github.com/btcsuite/goleveldb
   version: 7834afc9e8cd15233b6c3d97e12674a31ca24602
   subpackages:
@@ -39,7 +35,7 @@ imports:
 - name: github.com/decred/blake256
   version: a840e32d7c31fe2e0218607334cb120a683951a4
 - name: github.com/decred/dcrd
-  version: 54d1da3151ee8883399ffdf114d2a49196423e42
+  version: ecd27f0d4d0b6a9b6b64ee4c38eaab2c4b81e557
   subpackages:
   - blockchain
   - blockchain/internal/dbnamespace
@@ -61,46 +57,59 @@ imports:
   - txscript
   - wire
 - name: github.com/decred/dcrrpcclient
-  version: 85287b52629eac30af788b2a03a985590fac1fe8
+  version: d6edcb0f8f2d01fbf9169f240f73756b41423189
 - name: github.com/decred/dcrutil
-  version: ba0a5f399a43abc0e1a0a0442509c36f35321bce
+  version: ebd2e98736e819ac043d54439969b30144b92ced
   subpackages:
   - base58
+  - hdkeychain
 - name: github.com/decred/dcrwallet
-  version: 43620621173cdfb7997ccb10fe29321d412aa8e6
+  version: f554425c18066a374f6536e8d8bc3249a636b5dc
   subpackages:
+  - apperrors
+  - chain
+  - internal/zero
   - netparams
+  - snacl
+  - wallet/txrules
+  - wallet/udb
   - walletdb
-  - wtxmgr
 - name: github.com/decred/ed25519
   version: b0909d3f798b97a03c9e77023f97a5301a2a7900
   subpackages:
   - edwards25519
 - name: github.com/mattn/go-colorable
-  version: acb9493f2794fd0f820de7a27a217dafbb1b65ea
+  version: ded68f7a9561c023e790de24279db7ebf473ea80
 - name: github.com/mattn/go-isatty
-  version: 9622e0cc9d8f9be434ca605520ff9a16808fee47
+  version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
 - name: github.com/mattn/go-sqlite3
   version: ca5e3819723d8eeaf170ad510e7da1d6d2e94a08
 - name: github.com/mgutz/ansi
   version: 9520e82c474b0a04dd04f8a40959027271bab992
-- name: github.com/oleiade/lane
-  version: 28f7c3f09254f12b51e620fa4db136ba58804762
 - name: github.com/pressly/chi
-  version: 57ee7612d4405274628c71d1dc9455a12646f056
+  version: a57b1fbe2989382bdef31d3793d4a50a0e4a1d7c
   subpackages:
   - docgen
   - middleware
 - name: github.com/shiena/ansicolor
   version: a422bbe96644373c5753384a59d678f7d261ff10
 - name: github.com/Sirupsen/logrus
-  version: 0208149b40d863d2c1a2f8fe5753096a9cf2cc8b
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+- name: golang.org/x/crypto
+  version: 122d919ec1efcfb58483215da23f815853e24b81
+  subpackages:
+  - nacl/secretbox
+  - pbkdf2
+  - poly1305
+  - ripemd160
+  - salsa20/salsa
+  - scrypt
 - name: golang.org/x/net
-  version: b4690f45fa1cafc47b1c280c2e75116efe40cc13
+  version: da118f7b8e5954f39d0d2130ab35d4bf0e3cb344
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: e24f485414aeafb646f6fca458b0bf869c0880a1
+  version: 9ccfe848b9db8435a24c424abbc07a921adf1df5
   subpackages:
   - unix
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,14 +1,20 @@
 package: github.com/dcrdata/dcrdata
 import:
+- package: github.com/Sirupsen/logrus
+  version: ~0.11.5
 - package: github.com/btcsuite/btclog
 - package: github.com/btcsuite/go-flags
 - package: github.com/btcsuite/seelog
-  version: ^2.1.0
+  version: ~2.1.0
+- package: github.com/chappjc/logrus-prefix
 - package: github.com/decred/dcrd
   subpackages:
+  - blockchain
   - blockchain/stake
   - chaincfg
   - chaincfg/chainhash
+  - database
+  - database/ffldb
   - dcrjson
   - txscript
   - wire
@@ -17,13 +23,11 @@ import:
 - package: github.com/decred/dcrwallet
   subpackages:
   - netparams
-  - wtxmgr
+  - wallet/udb
+- package: github.com/mattn/go-sqlite3
+  version: ~1.2.0
 - package: github.com/pressly/chi
   subpackages:
   - docgen
   - middleware
-- package: github.com/mattn/go-sqlite3
-  version: ~1.2.0
-- package: github.com/btcsuite/snappy-go
-- package: github.com/oleiade/lane
-  version: ~1.0.0
+- package: github.com/shiena/ansicolor

--- a/log.go
+++ b/log.go
@@ -20,6 +20,7 @@ var (
 	backendLog = seelog.Disabled
 	log        = btclog.Disabled
 	sqliteLog  = btclog.Disabled
+	stakedbLog = btclog.Disabled
 	daemonLog  = btclog.Disabled
 	clientLog  = btclog.Disabled
 	mempoolLog = btclog.Disabled
@@ -30,6 +31,7 @@ var (
 var subsystemLoggers = map[string]btclog.Logger{
 	"DATD": log,
 	"DSQL": sqliteLog,
+	"SKDB": stakedbLog,
 	"DCRD": daemonLog,
 	"RPCC": clientLog,
 	"MEMP": mempoolLog,
@@ -65,6 +67,8 @@ func useLogger(subsystemID string, logger btclog.Logger) {
 		log = logger
 	case "DSQL":
 		sqliteLog = logger
+	case "SKDB":
+		stakedbLog = logger
 	case "DCRD":
 		daemonLog = logger
 	case "RPCC":

--- a/main.go
+++ b/main.go
@@ -212,6 +212,7 @@ func mainCore() int {
 	wg.Add(1)
 	go wsChainMonitor.BlockConnectedHandler()
 	//go wsChainMonitor.ReorgHandler()
+	ntfnChans.reorgChanBlockData = nil
 
 	// Blockchain monitor for the stake DB
 	sdbChainMonitor := sqliteDB.NewStakeDBChainMonitor(quit, &wg,
@@ -225,6 +226,8 @@ func mainCore() int {
 	// wg.Add(2)
 	// go wiredDBChainMonitor.BlockConnectedHandler()
 	// go wiredDBChainMonitor.ReorgHandler()
+	ntfnChans.reorgChanWiredDB = nil
+	ntfnChans.connectChanWiredDB = nil
 
 	if cfg.MonitorMempool {
 		mpoolCollector := mempool.NewMempoolDataCollector(dcrdClient, activeChain)

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dcrdata/dcrdata/mempool"
 	"github.com/dcrdata/dcrdata/rpcutils"
 	"github.com/dcrdata/dcrdata/semver"
+	"github.com/dcrdata/dcrdata/stakedb"
 	"github.com/dcrdata/dcrdata/txhelpers"
 	"github.com/decred/dcrrpcclient"
 	"github.com/pressly/chi"
@@ -122,11 +123,13 @@ func mainCore() int {
 	// blockDataSavers = append(blockDataSavers, blockDataMapSaver)
 
 	// Sqlite output
+	stakedb.UseLogger(sqliteLog)
 	dcrsqlite.UseLogger(sqliteLog)
 	dbInfo := dcrsqlite.DBInfo{FileName: cfg.DBFileName}
 	//sqliteDB, err := dcrsqlite.InitDB(&dbInfo)
-	sqliteDB, err := dcrsqlite.InitWiredDB(&dbInfo,
+	sqliteDB, cleanupDB, err := dcrsqlite.InitWiredDB(&dbInfo,
 		ntfnChans.updateStatusDBHeight, dcrdClient, activeChain)
+	defer cleanupDB()
 	if err != nil {
 		log.Errorf("Unable to initialize SQLite database: %v", err)
 		return 16

--- a/main.go
+++ b/main.go
@@ -123,7 +123,7 @@ func mainCore() int {
 	// blockDataSavers = append(blockDataSavers, blockDataMapSaver)
 
 	// Sqlite output
-	stakedb.UseLogger(sqliteLog)
+	stakedb.UseLogger(stakedbLog)
 	dcrsqlite.UseLogger(sqliteLog)
 	dbInfo := dcrsqlite.DBInfo{FileName: cfg.DBFileName}
 	//sqliteDB, err := dcrsqlite.InitDB(&dbInfo)

--- a/main.go
+++ b/main.go
@@ -142,6 +142,10 @@ func mainCore() int {
 
 	// Web template data. WebUI implements BlockDataSaver interface
 	webUI := NewWebUI()
+	if webUI == nil {
+		log.Info("Failed to start WebUI. Missing HTML resources?")
+		return 16
+	}
 	webUI.UseSIGToReloadTemplates()
 	blockDataSavers = append(blockDataSavers, webUI)
 	mempoolSavers = append(mempoolSavers, webUI)

--- a/main.go
+++ b/main.go
@@ -207,6 +207,12 @@ func mainCore() int {
 		ntfnChans.connectChan, ntfnChans.recvTxBlockChan)
 	go wsChainMonitor.BlockConnectedHandler()
 
+	// Blockchain monitor for the stake DB
+	wg.Add(1)
+	sdbChainMonitor := sqliteDB.NewChainMonitor(quit, &wg,
+		ntfnChans.connectChanStakeDB)
+	go sdbChainMonitor.BlockConnectedHandler()
+
 	if cfg.MonitorMempool {
 		mpoolCollector := mempool.NewMempoolDataCollector(dcrdClient, activeChain)
 		if mpoolCollector == nil {

--- a/main.go
+++ b/main.go
@@ -203,9 +203,11 @@ func mainCore() int {
 	addrMap := make(map[string]txhelpers.TxAction) // for support of watched addresses
 	wsChainMonitor := blockdata.NewChainMonitor(collector, blockDataSavers,
 		quit, &wg, !cfg.PoolValue, addrMap,
-		ntfnChans.connectChan, ntfnChans.recvTxBlockChan)
+		ntfnChans.connectChan, ntfnChans.recvTxBlockChan,
+		ntfnChans.reorgChanBlockData)
 	wg.Add(1)
 	go wsChainMonitor.BlockConnectedHandler()
+	//go wsChainMonitor.ReorgHandler()
 
 	// Blockchain monitor for the stake DB
 	sdbChainMonitor := sqliteDB.NewStakeDBChainMonitor(quit, &wg,
@@ -214,11 +216,11 @@ func mainCore() int {
 	go sdbChainMonitor.BlockConnectedHandler()
 	go sdbChainMonitor.ReorgHandler()
 
-	wiredDBChainMonitor := sqliteDB.NewChainMonitor(quit, &wg,
-		ntfnChans.connectChanWiredDB, ntfnChans.reorgChanWiredDB)
-	wg.Add(2)
-	go wiredDBChainMonitor.BlockConnectedHandler()
-	go wiredDBChainMonitor.ReorgHandler()
+	// wiredDBChainMonitor := sqliteDB.NewChainMonitor(quit, &wg,
+	// 	ntfnChans.connectChanWiredDB, ntfnChans.reorgChanWiredDB)
+	// wg.Add(2)
+	// go wiredDBChainMonitor.BlockConnectedHandler()
+	// go wiredDBChainMonitor.ReorgHandler()
 
 	if cfg.MonitorMempool {
 		mpoolCollector := mempool.NewMempoolDataCollector(dcrdClient, activeChain)

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 package mempool
 
 import (

--- a/mempool/mempoolcache.go
+++ b/mempool/mempoolcache.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 package mempool
 
 import (

--- a/ntfnchans.go
+++ b/ntfnchans.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// blockConnChanBuffer is the size of the block connected channel buffer.
-	blockConnChanBuffer = 24
+	blockConnChanBuffer = 64
 
 	// newTxChanBuffer is the size of the new transaction channel buffer, for
 	// ANY transactions are added into mempool.
@@ -26,6 +26,7 @@ const (
 var ntfnChans struct {
 	connectChan                       chan *chainhash.Hash
 	connectChanStkInf                 chan int32
+	connectChanStakeDB                chan *chainhash.Hash
 	updateStatusNodeHeight            chan uint32
 	updateStatusDBHeight              chan uint32
 	spendTxBlockChan, recvTxBlockChan chan *txhelpers.BlockWatchedTx
@@ -41,6 +42,9 @@ func makeNtfnChans(cfg *config) {
 	// quit channel case manages blockConnectedHandlers.
 	ntfnChans.connectChan = make(chan *chainhash.Hash, blockConnChanBuffer)
 	//ntfnChans.stakeDiffChan = make(chan int64, blockConnChanBuffer)
+
+	// Stake DB channel for connecting new blocks
+	ntfnChans.connectChanStakeDB = make(chan *chainhash.Hash, blockConnChanBuffer)
 
 	// Like connectChan for block data, connectChanStkInf is used when a new
 	// block is connected, but to signal the stake info monitor.
@@ -69,6 +73,9 @@ func closeNtfnChans() {
 	// }
 	if ntfnChans.connectChan != nil {
 		close(ntfnChans.connectChan)
+	}
+	if ntfnChans.connectChanStakeDB != nil {
+		close(ntfnChans.connectChanStakeDB)
 	}
 	if ntfnChans.connectChanStkInf != nil {
 		close(ntfnChans.connectChanStkInf)

--- a/ntfnchans.go
+++ b/ntfnchans.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"github.com/dcrdata/dcrdata/blockdata"
 	"github.com/dcrdata/dcrdata/dcrsqlite"
 	"github.com/dcrdata/dcrdata/stakedb"
 	"github.com/dcrdata/dcrdata/txhelpers"
@@ -29,6 +30,7 @@ const (
 // Channels are package-level variables for simplicity
 var ntfnChans struct {
 	connectChan                       chan *chainhash.Hash
+	reorgChanBlockData                chan *blockdata.ReorgData
 	connectChanStkInf                 chan int32
 	connectChanWiredDB                chan *chainhash.Hash
 	reorgChanWiredDB                  chan *dcrsqlite.ReorgData
@@ -61,6 +63,7 @@ func makeNtfnChans(cfg *config) {
 	ntfnChans.connectChanStkInf = make(chan int32, blockConnChanBuffer)
 
 	// Reorg data channels
+	ntfnChans.reorgChanBlockData = make(chan *blockdata.ReorgData, reorgBuffer)
 	ntfnChans.reorgChanWiredDB = make(chan *dcrsqlite.ReorgData, reorgBuffer)
 	ntfnChans.reorgChanStakeDB = make(chan *stakedb.ReorgData, reorgBuffer)
 
@@ -96,6 +99,9 @@ func closeNtfnChans() {
 	}
 	if ntfnChans.connectChanStkInf != nil {
 		close(ntfnChans.connectChanStkInf)
+	}
+	if ntfnChans.reorgChanBlockData != nil {
+		close(ntfnChans.reorgChanBlockData)
 	}
 	if ntfnChans.reorgChanWiredDB != nil {
 		close(ntfnChans.reorgChanWiredDB)

--- a/ntfnhandlers.go
+++ b/ntfnhandlers.go
@@ -66,8 +66,15 @@ func getNodeNtfnHandlers(cfg *config) *dcrrpcclient.NotificationHandlers {
 			}
 			height := int32(blockHeader.Height)
 			hash := blockHeader.BlockHash()
+
 			select {
 			case ntfnChans.connectChan <- &hash:
+			// send to nil channel blocks
+			default:
+			}
+
+			select {
+			case ntfnChans.connectChanStakeDB <- &hash:
 			// send to nil channel blocks
 			default:
 			}
@@ -107,7 +114,7 @@ func getNodeNtfnHandlers(cfg *config) *dcrrpcclient.NotificationHandlers {
 		OnNewTickets: func(hash *chainhash.Hash, height int64, stakeDiff int64,
 			tickets map[chainhash.Hash]chainhash.Hash) {
 			for _, tick := range tickets {
-				log.Debugf("Mined new ticket: %v", tick.String())
+				log.Tracef("Mined new ticket: %v", tick.String())
 			}
 		},
 		// OnRelevantTxAccepted is invoked when a transaction containing a

--- a/ntfnhandlers.go
+++ b/ntfnhandlers.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dcrdata/dcrdata/dcrsqlite"
+	"github.com/dcrdata/dcrdata/blockdata"
 	"github.com/dcrdata/dcrdata/stakedb"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
@@ -77,7 +77,6 @@ func getNodeNtfnHandlers(cfg *config) *dcrrpcclient.NotificationHandlers {
 
 			select {
 			case ntfnChans.connectChanWiredDB <- &hash:
-			// send to nil channel blocks
 			default:
 			}
 
@@ -102,7 +101,7 @@ func getNodeNtfnHandlers(cfg *config) *dcrrpcclient.NotificationHandlers {
 			newHash *chainhash.Hash, newHeight int32) {
 			// Send reorg data to dcrsqlite's monitor
 			select {
-			case ntfnChans.reorgChanWiredDB <- &dcrsqlite.ReorgData{
+			case ntfnChans.reorgChanBlockData <- &blockdata.ReorgData{
 				OldChainHead:   *oldHash,
 				OldChainHeight: oldHeight,
 				NewChainHead:   *newHash,

--- a/ntfnhandlers.go
+++ b/ntfnhandlers.go
@@ -138,11 +138,9 @@ func getNodeNtfnHandlers(cfg *config) *dcrrpcclient.NotificationHandlers {
 			}
 			log.Debugf("Winning tickets: %v", strings.Join(txstr, ", "))
 		},
-		// maturing tickets
-		// BUG: dcrrpcclient/notify.go (parseNewTicketsNtfnParams) is unable to
-		// Unmarshal fourth parameter as a map[hash]hash.
+		// maturing tickets. Thanks for fixing the tickets type bug, jolan!
 		OnNewTickets: func(hash *chainhash.Hash, height int64, stakeDiff int64,
-			tickets map[chainhash.Hash]chainhash.Hash) {
+			tickets []*chainhash.Hash) {
 			for _, tick := range tickets {
 				log.Tracef("Mined new ticket: %v", tick.String())
 			}

--- a/ntfnhandlers.go
+++ b/ntfnhandlers.go
@@ -11,7 +11,7 @@ import (
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrrpcclient"
 	"github.com/decred/dcrutil"
-	"github.com/decred/dcrwallet/wtxmgr"
+	"github.com/decred/dcrwallet/wallet/udb"
 )
 
 func registerNodeNtfnHandlers(dcrdClient *dcrrpcclient.Client) *ContextualError {
@@ -120,7 +120,7 @@ func getNodeNtfnHandlers(cfg *config) *dcrrpcclient.NotificationHandlers {
 		// OnRelevantTxAccepted is invoked when a transaction containing a
 		// registered address is inserted into mempool.
 		OnRelevantTxAccepted: func(transaction []byte) {
-			rec, err := wtxmgr.NewTxRecord(transaction, time.Now())
+			rec, err := udb.NewTxRecord(transaction, time.Now())
 			if err != nil {
 				return
 			}

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -13,6 +13,7 @@ import (
 	apitypes "github.com/dcrdata/dcrdata/dcrdataapi"
 	"github.com/dcrdata/dcrdata/semver"
 	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrrpcclient"
@@ -168,4 +169,19 @@ func GetStakeDiffEstimates(client *dcrrpcclient.Client) *apitypes.StakeDiff {
 		Estimates: *estStakeDiff,
 	}
 	return &stakeDiffEstimates
+}
+
+func GetBlock(ind int64, client *dcrrpcclient.Client) (*dcrutil.Block, *chainhash.Hash, error) {
+	blockhash, err := client.GetBlockHash(ind)
+	if err != nil {
+		return nil, nil, fmt.Errorf("GetBlockHash(%d) failed: %v", ind, err)
+	}
+
+	block, err := client.GetBlock(blockhash)
+	if err != nil {
+		return nil, blockhash,
+			fmt.Errorf("GetBlock failed (%s): %v", blockhash, err)
+	}
+
+	return block, blockhash, nil
 }

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -102,7 +102,7 @@ func BuildBlockHeaderVerbose(header *wire.BlockHeader, params *chaincfg.Params,
 
 	blockHeaderResult := dcrjson.GetBlockHeaderVerboseResult{
 		Hash:          header.BlockHash().String(),
-		Confirmations: uint64(currentHeight - int64(header.Height)),
+		Confirmations: int64(currentHeight - int64(header.Height)),
 		Version:       header.Version,
 		PreviousHash:  header.PrevBlock.String(),
 		MerkleRoot:    header.MerkleRoot.String(),

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -9,9 +9,9 @@ import (
 	"io/ioutil"
 	"strconv"
 
-	"github.com/dcrdata/dcrdata/blockdata"
 	apitypes "github.com/dcrdata/dcrdata/dcrdataapi"
 	"github.com/dcrdata/dcrdata/semver"
+	"github.com/dcrdata/dcrdata/txhelpers"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson"
@@ -93,7 +93,7 @@ func BuildBlockHeaderVerbose(header *wire.BlockHeader, params *chaincfg.Params,
 		return nil
 	}
 
-	diffRatio := blockdata.GetDifficultyRatio(header.Bits, params)
+	diffRatio := txhelpers.GetDifficultyRatio(header.Bits, params)
 
 	var next string
 	if len(nextHash) > 0 {

--- a/stakedb/chainmonitor.go
+++ b/stakedb/chainmonitor.go
@@ -1,0 +1,57 @@
+package stakedb
+
+import (
+	"sync"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+)
+
+// ChainMonitor connects blocks to the stake DB as they come in.
+type ChainMonitor struct {
+	db        *StakeDatabase
+	quit      chan struct{}
+	wg        *sync.WaitGroup
+	blockChan chan *chainhash.Hash
+}
+
+// NewChainMonitor creates a new ChainMonitor
+func (db *StakeDatabase) NewChainMonitor(quit chan struct{}, wg *sync.WaitGroup,
+	blockChan chan *chainhash.Hash) *ChainMonitor {
+	return &ChainMonitor{
+		db:        db,
+		quit:      quit,
+		wg:        wg,
+		blockChan: blockChan,
+	}
+}
+
+// BlockConnectedHandler handles block connected notifications, which trigger
+// data collection and storage.
+func (p *ChainMonitor) BlockConnectedHandler() {
+	defer p.wg.Done()
+out:
+	for {
+	keepon:
+		select {
+		case hash, ok := <-p.blockChan:
+			if !ok {
+				log.Warnf("Block connected channel closed.")
+				break out
+			}
+			block, err := p.db.ConnectBlockHash(hash)
+			if err != nil {
+				log.Error(err)
+				break keepon
+			}
+
+			log.Infof("Connected block %d to stake DB.", block.Height())
+
+		case _, ok := <-p.quit:
+			if !ok {
+				log.Debugf("Got quit signal. Exiting block connected handler for BLOCK monitor.")
+				break out
+			}
+		}
+	}
+
+}

--- a/stakedb/chainmonitor.go
+++ b/stakedb/chainmonitor.go
@@ -69,17 +69,18 @@ out:
 				log.Infof("Adding block %v to sidechain", *hash)
 
 				// Just append to side chain until the new main chain tip block is reached
-				if !reorgData.NewChainHead.IsEqual(hash) {
+				if reorgData.NewChainHead != *hash {
 					break keepon
 				}
 
 				// Once all blocks in side chain are lined up, switch over
+				log.Info("Switching to side chain...")
 				newHeight, newHash, err := p.switchToSideChain()
 				if err != nil {
 					log.Error(err)
 				}
 
-				if !p.reorgData.NewChainHead.IsEqual(newHash) ||
+				if p.reorgData.NewChainHead != *newHash ||
 					p.reorgData.NewChainHeight != newHeight {
 					panic(fmt.Sprintf("Failed to reorg to %v. Got to %v (height %d) instead.",
 						p.reorgData.NewChainHead, newHash, newHeight))
@@ -105,7 +106,7 @@ out:
 
 		case _, ok := <-p.quit:
 			if !ok {
-				log.Debugf("Got quit signal. Exiting block connected handler for BLOCK monitor.")
+				log.Debugf("Got quit signal. Exiting block connected handler.")
 				break out
 			}
 		}
@@ -197,7 +198,7 @@ out:
 
 		case _, ok := <-p.quit:
 			if !ok {
-				log.Debugf("Got quit signal. Exiting block connected handler for REORG monitor.")
+				log.Debugf("Got quit signal. Exiting reorg notification handler.")
 				break out
 			}
 		}

--- a/stakedb/chainmonitor.go
+++ b/stakedb/chainmonitor.go
@@ -189,7 +189,7 @@ out:
 			}
 
 			newHeight, oldHeight := reorgData.NewChainHeight, reorgData.OldChainHeight
-			newHash, oldHash := reorgData.NewChainHeight, reorgData.OldChainHeight
+			newHash, oldHash := reorgData.NewChainHead, reorgData.OldChainHead
 
 			p.reorgLock.Lock()
 			if p.reorganizing {

--- a/stakedb/chainmonitor.go
+++ b/stakedb/chainmonitor.go
@@ -197,7 +197,7 @@ out:
 
 		case _, ok := <-p.quit:
 			if !ok {
-				log.Debugf("Got quit signal. Exiting block connected handler for BLOCK monitor.")
+				log.Debugf("Got quit signal. Exiting block connected handler for REORG monitor.")
 				break out
 			}
 		}

--- a/stakedb/chainmonitor.go
+++ b/stakedb/chainmonitor.go
@@ -77,7 +77,7 @@ out:
 				log.Info("Switching to side chain...")
 				newHeight, newHash, err := p.switchToSideChain()
 				if err != nil {
-					log.Error(err)
+					panic(err)
 				}
 
 				if p.reorgData.NewChainHead != *newHash ||

--- a/stakedb/chainmonitor.go
+++ b/stakedb/chainmonitor.go
@@ -125,10 +125,19 @@ func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 	// Determine highest common ancestor of side chain and main chain
 	block, err := p.db.NodeClient.GetBlock(&p.sideChain[0])
 	if err != nil {
-		return 0, nil, fmt.Errorf("unable to get block on side chain")
+		return 0, nil, fmt.Errorf("unable to get block at root of side chain")
 	}
 
-	commonAncestorHeight := int64(block.Height()) - 1
+	prevBlock, err := p.db.NodeClient.GetBlock(&block.MsgBlock().Header.PrevBlock)
+	if err != nil {
+		return 0, nil, fmt.Errorf("unable to get common ancestor on side chain")
+	}
+
+	commonAncestorHeight := block.Height() - 1
+	if prevBlock.Height() != commonAncestorHeight {
+		panic("Failed to determine common ancestor.")
+	}
+
 	mainTip := int64(p.db.Height())
 
 	// Disconnect blocks back to common ancestor

--- a/stakedb/chainmonitor.go
+++ b/stakedb/chainmonitor.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 package stakedb
 
 import (

--- a/stakedb/log.go
+++ b/stakedb/log.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2013-2015 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stakedb
+
+import "github.com/btcsuite/btclog"
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log = btclog.Disabled
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until either UseLogger or SetLogWriter are called.
+func DisableLog() {
+	log = btclog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -1,0 +1,201 @@
+package stakedb
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+
+	"sync"
+
+	"github.com/dcrdata/dcrdata/rpcutils"
+	"github.com/dcrdata/dcrdata/txhelpers"
+	"github.com/decred/dcrd/blockchain/stake"
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/database"
+	"github.com/decred/dcrrpcclient"
+	"github.com/decred/dcrutil"
+)
+
+type StakeDatabase struct {
+	params     *chaincfg.Params
+	NodeClient *dcrrpcclient.Client
+	StakeDB    database.DB
+	BestNode   *stake.Node
+	blkMtx     sync.RWMutex
+	blockCache map[int64]*dcrutil.Block
+}
+
+const (
+	// dbType is the database backend type to use
+	dbType = "ffldb"
+	// DefaultStakeDbName is the default database name
+	DefaultStakeDbName = "ffldb_stake"
+)
+
+func NewStakeDatabase(client *dcrrpcclient.Client, params *chaincfg.Params) (*StakeDatabase, error) {
+	sDB := &StakeDatabase{
+		params:     params,
+		NodeClient: client,
+		blockCache: make(map[int64]*dcrutil.Block),
+	}
+	if err := sDB.Open(); err != nil {
+		return nil, err
+	}
+	return sDB, nil
+}
+
+func (db *StakeDatabase) Height() uint32 {
+	if db == nil || db.BestNode == nil {
+		log.Error("Stake database not yet opened")
+		return 0
+	}
+	return db.BestNode.Height()
+}
+
+func (db *StakeDatabase) Block(ind int64) (*dcrutil.Block, bool) {
+	db.blkMtx.RLock()
+	defer db.blkMtx.RUnlock()
+	block, ok := db.blockCache[ind]
+	//log.Info(ind, block, ok)
+	if !ok {
+		var err error
+		block, _, err = rpcutils.GetBlock(ind, db.NodeClient)
+		if err != nil {
+			log.Error(err)
+			return nil, false
+		}
+	}
+	return block, ok
+}
+
+func (db *StakeDatabase) ForgetBlock(ind int64) {
+	db.blkMtx.Lock()
+	defer db.blkMtx.Unlock()
+	delete(db.blockCache, ind)
+}
+
+func (db *StakeDatabase) ConnectBlockHeight(height int64) error {
+	block, _ := db.Block(height)
+	return db.ConnectBlock(block)
+}
+
+func (db *StakeDatabase) ConnectBlock(block *dcrutil.Block) error {
+	height := block.Height()
+	maturingHeight := height - int64(db.params.TicketMaturity)
+	//log.Info("Connect ", height, maturingHeight)
+	var maturingTickets []chainhash.Hash
+	if maturingHeight >= 0 {
+		maturingBlock, wasCached := db.Block(maturingHeight)
+		if wasCached {
+			db.ForgetBlock(maturingHeight)
+		}
+		maturingTickets = txhelpers.TicketsInBlock(maturingBlock)
+	}
+
+	db.blkMtx.Lock()
+	db.blockCache[block.Height()] = block
+	db.blkMtx.Unlock()
+
+	revokedTickets := txhelpers.RevokedTicketsInBlock(block)
+	spentTickets := txhelpers.TicketsSpentInBlock(block)
+
+	//log.Info("Connect ", len(revokedTickets), len(spentTickets), len(maturingTickets))
+
+	return db.connectBlock(block, spentTickets, revokedTickets, maturingTickets)
+}
+
+func (db *StakeDatabase) connectBlock(block *dcrutil.Block, spent []chainhash.Hash,
+	revoked []chainhash.Hash, maturing []chainhash.Hash) error {
+
+	var err error
+	db.BestNode, err = db.BestNode.ConnectNode(block.MsgBlock().Header,
+		spent, revoked, maturing)
+	if err != nil {
+		return err
+	}
+
+	// Write the new node to db
+	return db.StakeDB.Update(func(dbTx database.Tx) error {
+		return stake.WriteConnectedBestNode(dbTx, db.BestNode, *block.Hash())
+	})
+}
+
+func (db *StakeDatabase) DisconnectBlock() error {
+	formerBestNode := db.BestNode
+	parentBlock, _ := db.Block(int64(db.Height()) - 1)
+	if parentBlock == nil {
+		return fmt.Errorf("Unable to get parent block")
+	}
+
+	// previous best node
+	err := db.StakeDB.View(func(dbTx database.Tx) error {
+		var errLocal error
+		db.BestNode, errLocal = db.BestNode.DisconnectNode(
+			parentBlock.MsgBlock().Header, nil, nil, dbTx)
+		return errLocal
+	})
+	if err != nil {
+		return err
+	}
+
+	return db.StakeDB.Update(func(dbTx database.Tx) error {
+		return stake.WriteDisconnectedBestNode(dbTx, db.BestNode,
+			*parentBlock.Hash(), formerBestNode.UndoData())
+	})
+}
+
+func (db *StakeDatabase) Open() error {
+	// Create a new database to store the accepted stake node data into.
+	dbName := DefaultStakeDbName
+	var err error
+	db.StakeDB, err = database.Open(dbType, dbName, db.params.Net)
+	if err != nil {
+		log.Infof("Unable to open stake DB (%v). Removing and creating new.", err)
+		_ = os.RemoveAll(dbName)
+		db.StakeDB, err = database.Create(dbType, dbName, db.params.Net)
+		if err != nil {
+			// do not return nil interface, but interface of nil DB
+			return fmt.Errorf("error creating db: %v", err)
+		}
+	}
+
+	// Load the best block from stake db
+	var bestNodeHeight = int64(-1)
+	err = db.StakeDB.View(func(dbTx database.Tx) error {
+		v := dbTx.Metadata().Get([]byte("stakechainstate"))
+		if v == nil {
+			return fmt.Errorf("missing key for chain state data")
+		}
+
+		var stakeDBHash chainhash.Hash
+		copy(stakeDBHash[:], v[:chainhash.HashSize])
+		offset := chainhash.HashSize
+		stakeDBHeight := binary.LittleEndian.Uint32(v[offset : offset+4])
+		bestNodeHeight = int64(stakeDBHeight)
+
+		var errLocal error
+		block, errLocal := db.NodeClient.GetBlock(&stakeDBHash)
+		if errLocal != nil {
+			return fmt.Errorf("GetBlock failed (%s): %v", stakeDBHash, errLocal)
+		}
+		header := block.MsgBlock().Header
+
+		db.BestNode, errLocal = stake.LoadBestNode(dbTx, stakeDBHeight,
+			stakeDBHash, header, db.params)
+		return errLocal
+	})
+	if err != nil {
+		log.Errorf("Error reading from database (%v).  Reinitializing.", err)
+		err = db.StakeDB.Update(func(dbTx database.Tx) error {
+			var errLocal error
+			db.BestNode, errLocal = stake.InitDatabaseState(dbTx, db.params)
+			return errLocal
+		})
+		log.Debug("Created new stake db.")
+	} else {
+		log.Debug("Opened existing stake db.")
+	}
+
+	return err
+}

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -75,9 +75,17 @@ func (db *StakeDatabase) ForgetBlock(ind int64) {
 	delete(db.blockCache, ind)
 }
 
-func (db *StakeDatabase) ConnectBlockHeight(height int64) error {
+func (db *StakeDatabase) ConnectBlockHeight(height int64) (*dcrutil.Block, error) {
 	block, _ := db.Block(height)
-	return db.ConnectBlock(block)
+	return block, db.ConnectBlock(block)
+}
+
+func (db *StakeDatabase) ConnectBlockHash(hash *chainhash.Hash) (*dcrutil.Block, error) {
+	block, err := db.NodeClient.GetBlock(hash)
+	if err != nil {
+		return nil, err
+	}
+	return block, db.ConnectBlock(block)
 }
 
 func (db *StakeDatabase) ConnectBlock(block *dcrutil.Block) error {

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 package stakedb
 
 import (

--- a/version.go
+++ b/version.go
@@ -10,9 +10,9 @@ type version struct {
 
 var ver = version{
 	Major: 0,
-	Minor: 2,
-	Patch: 1,
-	Label: "alpha"}
+	Minor: 3,
+	Patch: 0,
+	Label: "beta"}
 
 // CommitHash may be set on the build command line:
 // go build -ldflags "-X main.CommitHash=`git rev-parse --short HEAD`"

--- a/web.go
+++ b/web.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017, Jonathan Chappelow
+// See LICENSE for details.
+
 package main
 
 import (

--- a/web.go
+++ b/web.go
@@ -34,12 +34,12 @@ type WebTemplateData struct {
 }
 
 type WebUI struct {
-	MPC          mempool.MempoolDataCache
-	TemplateData WebTemplateData
+	MPC             mempool.MempoolDataCache
+	TemplateData    WebTemplateData
 	templateDataMtx sync.RWMutex
-	templ        *template.Template
-	templFiles   []string
-	params       *chaincfg.Params
+	templ           *template.Template
+	templFiles      []string
+	params          *chaincfg.Params
 }
 
 func NewWebUI() *WebUI {


### PR DESCRIPTION
Addresses https://github.com/dcrdata/dcrdata/issues/26

This adds `package stakedb` to manage the `dcrd/database.DB` used to track the live ticket pool.  It simplifies startup sync and it has a notification handler to stay updated as blocks come in after the sync.

The dependencies are also updated to Decred 1.0.1 versions.