### PR TITLE
Make blockdata Collect use block hash-specific functions where possible

### DIFF
--- a/blockdata/chainmonitor.go
+++ b/blockdata/chainmonitor.go
@@ -25,7 +25,6 @@ type chainMonitor struct {
 	dataSavers      []BlockDataSaver
 	quit            chan struct{}
 	wg              *sync.WaitGroup
-	noTicketPool    bool
 	watchaddrs      map[string]txhelpers.TxAction
 	blockChan       chan *chainhash.Hash
 	recvTxBlockChan chan *txhelpers.BlockWatchedTx
@@ -41,7 +40,7 @@ type chainMonitor struct {
 // NewChainMonitor creates a new chainMonitor
 func NewChainMonitor(collector *blockDataCollector,
 	savers []BlockDataSaver,
-	quit chan struct{}, wg *sync.WaitGroup, noPoolValue bool,
+	quit chan struct{}, wg *sync.WaitGroup,
 	addrs map[string]txhelpers.TxAction, blockChan chan *chainhash.Hash,
 	recvTxBlockChan chan *txhelpers.BlockWatchedTx,
 	reorgChan chan *ReorgData) *chainMonitor {
@@ -50,7 +49,6 @@ func NewChainMonitor(collector *blockDataCollector,
 		dataSavers:      savers,
 		quit:            quit,
 		wg:              wg,
-		noTicketPool:    noPoolValue,
 		watchaddrs:      addrs,
 		blockChan:       blockChan,
 		recvTxBlockChan: recvTxBlockChan,
@@ -119,7 +117,7 @@ out:
 			bdataChan := make(chan *BlockData)
 			// fire it off and get the BlockData pointer back through the channel
 			go func() {
-				BlockData, err := p.collector.Collect(p.noTicketPool)
+				BlockData, err := p.collector.Collect()
 				if err != nil {
 					log.Errorf("Block data collection failed: %v", err.Error())
 					// BlockData is nil when err != nil

--- a/config.go
+++ b/config.go
@@ -81,7 +81,6 @@ type config struct {
 	MPTriggerTickets   int  `long:"mp-ticket-trigger" description:"The number minimum number of new tickets that must be seen to trigger a new mempool report."`
 	//FeeWinRadius       int    `short:"r" long:"feewinradius" description:"Half-width of a window around the ticket with the lowest mineable fee."`
 	DumpAllMPTix bool   `long:"dumpallmptix" description:"Dump to file the fees of all the tickets in mempool."`
-	PoolValue    bool   `short:"p" long:"poolvalue" description:"Collect ticket pool value information (8-9 sec)."`
 	DBFileName   string `long:"dbfile" description:"SQLite DB file name (default is dcrdata.sqlt.db)."`
 
 	//WatchAddresses []string `short:"w" long:"watchaddress" description:"Watched address (receiving). One per line."`

--- a/dcrsqlite/sync.go
+++ b/dcrsqlite/sync.go
@@ -258,7 +258,7 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 				i, endRangeBlock, numLive)
 		}
 
-		tpi := db.sDB.PoolInfo()
+		tpi, _ := db.sDB.PoolInfo()
 
 		header := block.MsgBlock().Header
 		diffRatio := txhelpers.GetDifficultyRatio(header.Bits, db.params)

--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func mainCore() int {
 	mempoolSavers = append(mempoolSavers, webUI)
 
 	// Initial data summary for web ui
-	blockData, err := collector.Collect(!cfg.PoolValue)
+	blockData, err := collector.Collect()
 	if err != nil {
 		log.Errorf("Block data collection for initial summary failed: %v",
 			err.Error())
@@ -210,7 +210,7 @@ func mainCore() int {
 	addrMap := make(map[string]txhelpers.TxAction) // for support of watched addresses
 	ntfnChans.reorgChanBlockData = nil
 	wsChainMonitor := blockdata.NewChainMonitor(collector, blockDataSavers,
-		quit, &wg, !cfg.PoolValue, addrMap,
+		quit, &wg, addrMap,
 		ntfnChans.connectChan, ntfnChans.recvTxBlockChan,
 		ntfnChans.reorgChanBlockData)
 	wg.Add(1)

--- a/sample-dcrdata.conf
+++ b/sample-dcrdata.conf
@@ -3,9 +3,6 @@
 debuglevel=debug
 ;debuglevel=DATD=debug,DSQL=debug,MEMP=debug,DCRD=info,RPCC=info,JAPI=debug
 
-; Ticket pool value takes a long time, ~2 sec (default is true)
-;poolvalue=true
-
 dcrduser=duser
 dcrdpass=asdfExample
 

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -348,7 +348,7 @@ func (db *StakeDatabase) Open() error {
 // PoolInfo computes ticket pool value using the database and, if needed, the
 // node RPC client to fetch ticket values that are not cached. Returned are a
 // structure including ticket pool value, size, and average value.
-func (db *StakeDatabase) PoolInfo() apitypes.TicketPoolInfo {
+func (db *StakeDatabase) PoolInfo() (apitypes.TicketPoolInfo, uint32) {
 	// Wait for BlockConnectedHandler to finish, it someone like the
 	// OnBlockConnected notification handler said to wait.
 	db.ConnectingLock <- struct{}{}
@@ -357,6 +357,7 @@ func (db *StakeDatabase) PoolInfo() apitypes.TicketPoolInfo {
 	db.nodeMtx.RLock()
 	poolSize := db.BestNode.PoolSize()
 	liveTickets := db.BestNode.LiveTickets()
+	height := db.BestNode.Height()
 	db.nodeMtx.RUnlock()
 
 	db.liveTicketMtx.Lock()
@@ -394,7 +395,7 @@ func (db *StakeDatabase) PoolInfo() apitypes.TicketPoolInfo {
 		Size:   uint32(poolSize),
 		Value:  poolCoin,
 		ValAvg: valAvg,
-	}
+	}, height
 }
 
 // PoolSize returns the ticket pool size in the best node of the stake database


### PR DESCRIPTION
- Add `CollectBlockInfo` to get by hash most data.
- Remove (no)poolinfo option.  Delete it from dcrdata.conf or dcrdata will not start.
- Give `stakedb.PoolInfo()` a second output, the height of the stake node.
- Bump version to 0.3.3.