### PR TITLE
Switch chi import path, update to chi 3.0

### DIFF
--- a/apimiddleware.go
+++ b/apimiddleware.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/pressly/chi"
-	"github.com/pressly/chi/docgen"
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/docgen"
 	//"github.com/decred/dcrrpcclient"
 )
 

--- a/apirouter.go
+++ b/apirouter.go
@@ -3,8 +3,8 @@ package main
 import (
 	"net/http"
 
-	"github.com/pressly/chi"
-	"github.com/pressly/chi/middleware"
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
 )
 
 type apiMux struct {
@@ -39,14 +39,14 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
 		})
 
-		r.Route("/:idx", func(rd chi.Router) {
+		r.Route("/{idx}", func(rd chi.Router) {
 			rd.Use(BlockIndexPathCtx)
 			rd.Get("/", app.getBlockSummary)
 			rd.Get("/header", app.getBlockHeader)
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
 		})
 
-		r.Route("/range/:idx0/:idx", func(rd chi.Router) {
+		r.Route("/range/{idx0}/{idx}", func(rd chi.Router) {
 			rd.Use(BlockIndex0PathCtx, BlockIndexPathCtx)
 			rd.Get("/", app.getBlockRangeSummary)
 			// rd.Get("/header", app.getBlockHeader)
@@ -59,15 +59,15 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 	mux.Route("/stake", func(r chi.Router) {
 		r.Route("/pool", func(rd chi.Router) {
 			rd.With(app.BlockIndexLatestCtx).Get("/", app.getTicketPoolInfo)
-			rd.With(BlockIndexPathCtx).Get("/b/:idx", app.getTicketPoolInfo)
-			rd.With(BlockIndex0PathCtx, BlockIndexPathCtx).Get("/r/:idx0/:idx", app.getTicketPoolInfoRange)
+			rd.With(BlockIndexPathCtx).Get("/b/{idx}", app.getTicketPoolInfo)
+			rd.With(BlockIndex0PathCtx, BlockIndexPathCtx).Get("/r/{idx0}/{idx}", app.getTicketPoolInfoRange)
 		})
 		r.Route("/diff", func(rd chi.Router) {
 			rd.Get("/", app.getStakeDiffSummary)
 			rd.Get("/current", app.getStakeDiffCurrent)
 			rd.Get("/estimates", app.getStakeDiffEstimates)
-			rd.With(BlockIndexPathCtx).Get("/b/:idx", app.getStakeDiff)
-			rd.With(BlockIndex0PathCtx, BlockIndexPathCtx).Get("/r/:idx0/:idx", app.getStakeDiffRange)
+			rd.With(BlockIndexPathCtx).Get("/b/{idx}", app.getStakeDiff)
+			rd.With(BlockIndex0PathCtx, BlockIndexPathCtx).Get("/r/{idx0}/{idx}", app.getStakeDiffRange)
 		})
 	})
 
@@ -77,9 +77,9 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 		r.Route("/sstx", func(rd chi.Router) {
 			rd.Get("/", app.getSSTxSummary)
 			rd.Get("/fees", app.getSSTxFees)
-			rd.With(NPathCtx).Get("/fees/:N", app.getSSTxFees)
+			rd.With(NPathCtx).Get("/fees/{N}", app.getSSTxFees)
 			rd.Get("/details", app.getSSTxDetails)
-			rd.With(NPathCtx).Get("/details/:N", app.getSSTxDetails)
+			rd.With(NPathCtx).Get("/details/{N}", app.getSSTxDetails)
 		})
 	})
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: dcdb75bac42f5ef04d88ae53ced7d62231b8843c2abde2e79aab2bea9c36eca8
-updated: 2017-06-20T20:07:07.353586651-07:00
+hash: 3730d1306d1349a37e40fe9b782e49365be3b23a262d905927aa362c2c7385ab
+updated: 2017-07-03T08:39:59.015835655-07:00
 imports:
 - name: github.com/agl/ed25519
   version: 278e1ec8e8a6e017cd07577924d6766039146ced
@@ -37,7 +37,7 @@ imports:
 - name: github.com/decred/blake256
   version: a840e32d7c31fe2e0218607334cb120a683951a4
 - name: github.com/decred/dcrd
-  version: 0d406ffde87da224466ba5c83548941e15179872
+  version: 2ffbad1e88455c294811c2ff9ff19518d8a08e2e
   subpackages:
   - blockchain
   - blockchain/internal/dbnamespace
@@ -66,16 +66,20 @@ imports:
   - base58
   - hdkeychain
 - name: github.com/decred/dcrwallet
-  version: 6a50ff0b9188af4b2dec68e42add0028c97fb11c
+  version: 61d5607bd4f579d85430728b07a7c64e79da9fb2
   subpackages:
   - apperrors
   - chain
   - internal/zero
   - netparams
   - snacl
-  - wallet/txrules
   - wallet/udb
   - walletdb
+- name: github.com/go-chi/chi
+  version: 967844826e58cf31213a7dfb82455d242ad85101
+  subpackages:
+  - docgen
+  - middleware
 - name: github.com/jrick/logrotate
   version: 4ed05ed86ef17d10ff99cce77481e0fcf6f2c7b0
   subpackages:
@@ -85,20 +89,15 @@ imports:
 - name: github.com/mattn/go-isatty
   version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
 - name: github.com/mattn/go-sqlite3
-  version: afe454f6220b3972691678af2c5579781563183f
+  version: 8a4c825cfc99b620bd78dbeac30348782a3b3eb9
 - name: github.com/mgutz/ansi
   version: 9520e82c474b0a04dd04f8a40959027271bab992
-- name: github.com/pressly/chi
-  version: d96632ea8f31cab87b99211cf6e651ada1420ca8
-  subpackages:
-  - docgen
-  - middleware
 - name: github.com/shiena/ansicolor
   version: a422bbe96644373c5753384a59d678f7d261ff10
 - name: github.com/Sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: golang.org/x/crypto
-  version: adbae1b6b6fb4b02448a0fc0dbbc9ba2b95b294d
+  version: 5746f0a2e262b80ccdf839a4a37a6b97962210f1
   subpackages:
   - nacl/secretbox
   - pbkdf2
@@ -107,11 +106,11 @@ imports:
   - salsa20/salsa
   - scrypt
 - name: golang.org/x/net
-  version: fe686d45ea04bc1bd4eff6a52865ce8757320325
+  version: 5f8847ae0d0e90b6a9dc8148e7ad616874625171
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: fb4cac33e3196ff7f507ab9b2d2a44b0142f5b5a
+  version: 0e0164865330d5cf1c00247be08330bf96e2f87c
   subpackages:
   - unix
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,8 +23,6 @@ import:
   - netparams
   - wallet/udb
 - package: github.com/mattn/go-sqlite3
-- package: github.com/pressly/chi
-  subpackages:
-  - docgen
-  - middleware
 - package: github.com/shiena/ansicolor
+- package: github.com/go-chi/chi
+  version: ~3.0.0

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/dcrdata/dcrdata/semver"
 	"github.com/dcrdata/dcrdata/txhelpers"
 	"github.com/decred/dcrrpcclient"
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 )
 
 // mainCore does all the work. Deferred functions do not run after os.Exit(),
@@ -302,10 +302,10 @@ func mainCore() int {
 	webMux.Get("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "./public/images/favicon.ico")
 	})
-	webMux.FileServer("/js", http.Dir("./public/js"))
-	webMux.FileServer("/css", http.Dir("./public/css"))
-	webMux.FileServer("/fonts", http.Dir("./public/fonts"))
-	webMux.FileServer("/images", http.Dir("./public/images"))
+	FileServer(webMux, "/js", http.Dir("./public/js"))
+	FileServer(webMux, "/css", http.Dir("./public/css"))
+	FileServer(webMux, "/fonts", http.Dir("./public/fonts"))
+	FileServer(webMux, "/images", http.Dir("./public/images"))
 	webMux.NotFound(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, r.URL.RequestURI()+" ain't no country I've ever heard of! (404)", http.StatusNotFound)
 	})


### PR DESCRIPTION
chi has moved from github.com/pressly/chi to github.com/go-chi/chi.  Change this in source and in glide.

Also update to using v3.0 of chi, which changes for dcrdata:

1. FileServer removed so we add our own implementation.
2. url parameters are now specified with `/{param}` instead of `/:param`