### PR TITLE
Delay call to mempool collection so block data can go first

### DIFF
--- a/dcrsqlite/sqlite.go
+++ b/dcrsqlite/sqlite.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/btcsuite/btclog"
 	"github.com/dcrdata/dcrdata/blockdata"
 	apitypes "github.com/dcrdata/dcrdata/dcrdataapi"
 	_ "github.com/mattn/go-sqlite3" // register sqlite driver with database/sql
@@ -502,14 +503,21 @@ func (db *DB) RetrieveStakeInfoExtended(ind int64) (*apitypes.StakeInfoExtended,
 }
 
 func logDBResult(res sql.Result) error {
+	if log.Level() > btclog.LevelTrace {
+		return nil
+	}
+
 	lastID, err := res.LastInsertId()
 	if err != nil {
 		return err
+
 	}
 	rowCnt, err := res.RowsAffected()
 	if err != nil {
 		return err
 	}
+
 	log.Tracef("ID = %d, affected = %d", lastID, rowCnt)
+
 	return nil
 }

--- a/dcrsqlite/sync.go
+++ b/dcrsqlite/sync.go
@@ -240,10 +240,6 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 			}
 		}
 
-		if i < startHeight {
-			continue
-		}
-
 		numLive := db.sDB.BestNode.PoolSize()
 		//liveTickets := db.sDB.BestNode.LiveTickets()
 		// TODO: winning tickets

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -155,6 +155,7 @@ func (p *mempoolMonitor) TxHandler(client *dcrrpcclient.Client) {
 				if uint32(bestBlock) <= p.mpoolInfo.CurrentHeight {
 					continue
 				}
+				time.Sleep(500 * time.Millisecond)
 				log.Debugf("Vote in new block triggering mempool data collection")
 			case stake.TxTypeSSRtx:
 				// Revoke


### PR DESCRIPTION
This puts a band-aid on the issue of a mempool data collection being initiated before the new block data collection,  which is a problem when mempool collection is retarded by numerous sstx.  There needs to be proper synchronization to prevent mempool collection before block data collection can run.

Also remove some useless code, and optimize `logDBResult` when log level is above trace.