### PR TITLE
Reorg handling for dcrsqlite

### DIFF
--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -18,7 +18,7 @@ import (
 	"github.com/decred/dcrutil"
 )
 
-// BlockData contains all the data collected by a blockDataCollector and stored
+// BlockData contains all the data collected by a Collector and stored
 // by a BlockDataSaver. TODO: consider if pointers are desirable here.
 type BlockData struct {
 	Header           dcrjson.GetBlockHeaderVerboseResult
@@ -66,17 +66,17 @@ func (b *BlockData) ToBlockSummary() apitypes.BlockDataBasic {
 	}
 }
 
-type blockDataCollector struct {
+type Collector struct {
 	mtx          sync.Mutex
 	dcrdChainSvr *dcrrpcclient.Client
 	netParams    *chaincfg.Params
 	stakeDB      *stakedb.StakeDatabase
 }
 
-// NewBlockDataCollector creates a new blockDataCollector.
-func NewBlockDataCollector(dcrdChainSvr *dcrrpcclient.Client, params *chaincfg.Params,
-	stakeDB *stakedb.StakeDatabase) *blockDataCollector {
-	return &blockDataCollector{
+// NewCollector creates a new Collector.
+func NewCollector(dcrdChainSvr *dcrrpcclient.Client, params *chaincfg.Params,
+	stakeDB *stakedb.StakeDatabase) *Collector {
+	return &Collector{
 		mtx:          sync.Mutex{},
 		dcrdChainSvr: dcrdChainSvr,
 		netParams:    params,
@@ -84,7 +84,27 @@ func NewBlockDataCollector(dcrdChainSvr *dcrrpcclient.Client, params *chaincfg.P
 	}
 }
 
-func (t *blockDataCollector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataBasic,
+func (t *Collector) CollectAPITypes(hash *chainhash.Hash) (*apitypes.BlockDataBasic, *apitypes.StakeInfoExtended) {
+	blockDataBasic, feeInfoBlock, _, err := t.CollectBlockInfo(hash)
+	if err != nil {
+		return nil, nil
+	}
+
+	height := int64(blockDataBasic.Height)
+	winSize := t.netParams.StakeDiffWindowSize
+
+	stakeInfoExtended := &apitypes.StakeInfoExtended{
+		Feeinfo:          *feeInfoBlock,
+		StakeDiff:        blockDataBasic.StakeDiff,
+		PriceWindowNum:   int(height / winSize),
+		IdxBlockInWindow: int(height%winSize) + 1,
+		PoolInfo:         blockDataBasic.PoolInfo,
+	}
+
+	return blockDataBasic, stakeInfoExtended
+}
+
+func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataBasic,
 	*dcrjson.FeeInfoBlock, *dcrjson.GetBlockHeaderVerboseResult, error) {
 	block, err := t.dcrdChainSvr.GetBlock(hash)
 	if err != nil {
@@ -130,7 +150,7 @@ func (t *blockDataCollector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.B
 
 // Collect is the main handler for collecting chain data at the current best
 // block. The input argument specifies if ticket pool value should be omitted.
-func (t *blockDataCollector) Collect() (*BlockData, error) {
+func (t *Collector) Collect() (*BlockData, error) {
 	// In case of a very fast block, make sure previous call to collect is not
 	// still running, or dcrd may be mad.
 	t.mtx.Lock()
@@ -138,7 +158,7 @@ func (t *blockDataCollector) Collect() (*BlockData, error) {
 
 	// Time this function
 	defer func(start time.Time) {
-		log.Debugf("blockDataCollector.Collect() completed in %v", time.Since(start))
+		log.Debugf("Collector.Collect() completed in %v", time.Since(start))
 	}(time.Now())
 
 	// Run first client call with a timeout

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -84,6 +84,8 @@ func NewCollector(dcrdChainSvr *dcrrpcclient.Client, params *chaincfg.Params,
 	}
 }
 
+// CollectAPITypes uses CollectBlockInfo to collect block data, then organizes
+// it into the BlockDataBasic and StakeInfoExtended and dcrdataapi types.
 func (t *Collector) CollectAPITypes(hash *chainhash.Hash) (*apitypes.BlockDataBasic, *apitypes.StakeInfoExtended) {
 	blockDataBasic, feeInfoBlock, _, err := t.CollectBlockInfo(hash)
 	if err != nil {
@@ -104,6 +106,9 @@ func (t *Collector) CollectAPITypes(hash *chainhash.Hash) (*apitypes.BlockDataBa
 	return blockDataBasic, stakeInfoExtended
 }
 
+// CollectBlockInfo uses the chain server and the stake DB to collect most of
+// the block data required by Collect() that is specific to the block with the
+// given hash.
 func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataBasic,
 	*dcrjson.FeeInfoBlock, *dcrjson.GetBlockHeaderVerboseResult, error) {
 	block, err := t.dcrdChainSvr.GetBlock(hash)

--- a/blockdata/chainmonitor.go
+++ b/blockdata/chainmonitor.go
@@ -21,7 +21,7 @@ type ReorgData struct {
 
 // for getblock, ticketfeeinfo, estimatestakediff, etc.
 type chainMonitor struct {
-	collector       *blockDataCollector
+	collector       *Collector
 	dataSavers      []BlockDataSaver
 	quit            chan struct{}
 	wg              *sync.WaitGroup
@@ -38,7 +38,7 @@ type chainMonitor struct {
 }
 
 // NewChainMonitor creates a new chainMonitor
-func NewChainMonitor(collector *blockDataCollector,
+func NewChainMonitor(collector *Collector,
 	savers []BlockDataSaver,
 	quit chan struct{}, wg *sync.WaitGroup,
 	addrs map[string]txhelpers.TxAction, blockChan chan *chainhash.Hash,

--- a/dcrsqlite/chainmonitor.go
+++ b/dcrsqlite/chainmonitor.go
@@ -107,9 +107,8 @@ out:
 
 }
 
-// switchToSideChain attempts to switch to a new side chain by: determining a
-// common ancestor block, disconnecting blocks from the main chain back to this
-// block, and connecting the side chain blocks onto the mainchain.
+// switchToSideChain attempts to switch to a side chain by collecting data for
+// each block in the side chain, and saving it as the new mainchain in sqlite.
 func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 	if len(p.sideChain) == 0 {
 		return 0, nil, fmt.Errorf("no side chain")
@@ -198,6 +197,9 @@ out:
 				break keepon
 			}
 
+			// Set the reorg flag so that when BlockConnectedHandler gets called
+			// for the side chain blocks, it knows to prepare then to be stored
+			// as main chain data.
 			p.reorganizing = true
 			p.reorgData = reorgData
 			p.reorgLock.Unlock()

--- a/dcrsqlite/sync.go
+++ b/dcrsqlite/sync.go
@@ -139,7 +139,7 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 	// Time this function
 	defer func(start time.Time, perr *error) {
 		if *perr != nil {
-			log.Infof("blockDataCollector.Collect() completed in %v", time.Since(start))
+			log.Infof("Collector.Collect() completed in %v", time.Since(start))
 		}
 	}(time.Now(), &err)
 

--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ func mainCore() int {
 	}
 
 	// Block data collector
-	collector := blockdata.NewBlockDataCollector(dcrdClient, activeChain, sqliteDB.GetStakeDB())
+	collector := blockdata.NewCollector(dcrdClient, activeChain, sqliteDB.GetStakeDB())
 	if collector == nil {
 		log.Errorf("Failed to create block data collector")
 		return 9
@@ -226,11 +226,11 @@ func mainCore() int {
 
 	ntfnChans.reorgChanWiredDB = nil
 	ntfnChans.connectChanWiredDB = nil
-	// wiredDBChainMonitor := sqliteDB.NewChainMonitor(quit, &wg,
-	// 	ntfnChans.connectChanWiredDB, ntfnChans.reorgChanWiredDB)
-	// wg.Add(2)
-	// go wiredDBChainMonitor.BlockConnectedHandler()
-	// go wiredDBChainMonitor.ReorgHandler()
+	wiredDBChainMonitor := sqliteDB.NewChainMonitor(collector, quit, &wg,
+		ntfnChans.connectChanWiredDB, ntfnChans.reorgChanWiredDB)
+	wg.Add(2)
+	go wiredDBChainMonitor.BlockConnectedHandler()
+	go wiredDBChainMonitor.ReorgHandler()
 
 	if cfg.MonitorMempool {
 		mpoolCollector := mempool.NewMempoolDataCollector(dcrdClient, activeChain)

--- a/main.go
+++ b/main.go
@@ -224,8 +224,7 @@ func mainCore() int {
 	go sdbChainMonitor.BlockConnectedHandler()
 	go sdbChainMonitor.ReorgHandler()
 
-	ntfnChans.reorgChanWiredDB = nil
-	ntfnChans.connectChanWiredDB = nil
+	// Blockchain monitor for the wired sqlite DB
 	wiredDBChainMonitor := sqliteDB.NewChainMonitor(collector, quit, &wg,
 		ntfnChans.connectChanWiredDB, ntfnChans.reorgChanWiredDB)
 	wg.Add(2)

--- a/version.go
+++ b/version.go
@@ -10,7 +10,7 @@ type version struct {
 
 var ver = version{
 	Major: 0,
-	Minor: 4,
+	Minor: 5,
 	Patch: 0,
 	Label: "beta"}
 


### PR DESCRIPTION
In `(*ChainMonitor).BlockConnectedHandler`, call `switchToSideChain`.
Implement `switchToSideChain()`: collect data for side chain blocks and store in sqlite.
Rename `blockdata.blockDataCollector` to `blockdata.Collector`.
Add a `blockdata.Collector` member to the `dcrsqlite.ChainMonitor`.
Create `(*Collector).CollectAPITypes` to get the `apitypes.BlockDataBasic` and `apitypes.StakeInfoExtended` needed to update blocks in sqlite during reorg.