### PR TITLE
Speed up block range API requests with a caching system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.log.*.gz
 *.bak
 debug
+debug.test
 *.cert
 *.key
 dcrdata

--- a/dcrdataapi/apicache.go
+++ b/dcrdataapi/apicache.go
@@ -1,0 +1,365 @@
+package dcrdataapi
+
+import (
+	"container/heap"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+)
+
+type CachedBlock struct {
+	summary    *BlockDataBasic
+	accesses   int64
+	accessTime int64
+	heapIdx    int
+}
+
+type blockCache map[chainhash.Hash]*CachedBlock
+
+type APICache struct {
+	sync.RWMutex
+	isEnabled       bool
+	capacity        uint32
+	blockCache                       // map[chainhash.Hash]*CachedBlock
+	MainchainBlocks []chainhash.Hash // needs to be handled in reorg
+	expireQueue     *BlockPriorityQueue
+}
+
+//var _ BlockSummarySaver = (*APICache)(nil)
+
+func (apic APICache) Capacity() uint32   { return apic.capacity }
+func (apic APICache) Utilization() int64 { return int64(len(apic.blockCache)) }
+
+func (apic *APICache) StoreBlockSummary(blockSummary *BlockDataBasic) error {
+	apic.Lock()
+	defer apic.Unlock()
+	if !apic.isEnabled {
+		fmt.Printf("API cache is disabled")
+		return nil
+	}
+
+	height := blockSummary.Height
+	hash, err := chainhash.NewHashFromStr(blockSummary.Hash)
+	if err != nil {
+		panic("that's not a real hash")
+	}
+
+	if len(apic.MainchainBlocks) < int(height) {
+		return fmt.Errorf("MainchainBlock slice too short (%d) add block at %d",
+			len(apic.MainchainBlocks), height)
+	}
+
+	if len(apic.MainchainBlocks) == int(height) {
+		// append
+		apic.MainchainBlocks = append(apic.MainchainBlocks, *hash)
+	} else /* > */ {
+		// update
+		apic.MainchainBlocks[int(height)] = *hash
+	}
+
+	_, ok := apic.blockCache[*hash]
+	if ok {
+		fmt.Printf("Already have the block summary in cache for block %s at height %d",
+			hash, height)
+		return nil
+	}
+
+	// insert into the cache and queue
+	cachedBlock := NewCachedBlock(blockSummary)
+	cachedBlock.Access()
+	apic.blockCache[*hash] = cachedBlock
+	apic.expireQueue.Insert(blockSummary)
+
+	return nil
+}
+
+func (apic *APICache) RemoveCachedBlock(cachedBlock *CachedBlock) {
+	// remove the block from the expiration queue
+	apic.expireQueue.RemoveBlock(cachedBlock)
+	// remove from block cache
+	if hash, err := chainhash.NewHashFromStr(cachedBlock.summary.Hash); err != nil {
+		delete(apic.blockCache, *hash)
+	}
+}
+
+func (apic *APICache) GetBlockSummary(height int64) *BlockDataBasic {
+	cachedBlock := apic.GetCachedBlockByHeight(height)
+	if cachedBlock != nil {
+		return cachedBlock.summary
+	}
+	return nil
+}
+
+func (apic *APICache) GetCachedBlockByHeight(height int64) *CachedBlock {
+	if int(height) > len(apic.MainchainBlocks) || height < 0 {
+		fmt.Printf("block not in MainchainBlocks map!")
+		return nil
+	}
+	hash := apic.MainchainBlocks[height]
+	return apic.GetCachedBlockByHash(hash)
+}
+
+func (apic *APICache) GetCachedBlockByHashStr(hashStr string) *CachedBlock {
+	hash, err := chainhash.NewHashFromStr(hashStr)
+	if err != nil {
+		fmt.Printf("that's not a real hash!")
+		return nil
+	}
+
+	return apic.getCachedBlockByHash(*hash)
+}
+
+func (apic *APICache) GetCachedBlockByHash(hash chainhash.Hash) *CachedBlock {
+	if _, err := chainhash.NewHashFromStr(hash.String()); err != nil {
+		fmt.Printf("that's not a real hash!")
+		return nil
+	}
+
+	return apic.getCachedBlockByHash(hash)
+}
+
+func (apic *APICache) getCachedBlockByHash(hash chainhash.Hash) *CachedBlock {
+	cachedBlock, ok := apic.blockCache[hash]
+	if ok {
+		cachedBlock.Access()
+		return cachedBlock
+	}
+	return nil
+}
+
+func (apic *APICache) Enable() {
+	apic.Lock()
+	defer apic.Unlock()
+	apic.isEnabled = true
+}
+
+func (apic *APICache) Disable() {
+	apic.Lock()
+	defer apic.Unlock()
+	apic.isEnabled = false
+}
+
+func NewAPICache(capacity uint32) *APICache {
+	return &APICache{
+		isEnabled:   true,
+		capacity:    capacity,
+		blockCache:  make(blockCache),
+		expireQueue: NewBlockPriorityQueue(capacity),
+	}
+}
+
+func NewCachedBlock(summary *BlockDataBasic) *CachedBlock {
+	return &CachedBlock{
+		summary:  summary,
+		accesses: 0,
+		heapIdx:  -1,
+	}
+}
+
+func (b *CachedBlock) Access() *BlockDataBasic {
+	b.accesses++
+	b.accessTime = time.Now().UnixNano()
+	return b.summary
+}
+
+func (b CachedBlock) String() string {
+	return fmt.Sprintf("{Height: %d, Accesses: %d, Time: %d, Heap Index: %d}",
+		b.summary.Height, b.accesses, b.accessTime, b.heapIdx)
+}
+
+type blockHeap []*CachedBlock
+
+// BlockPriorityQueue implements heap.Interface and holds CachedBlocks
+type BlockPriorityQueue struct {
+	bh                   blockHeap
+	capacity             uint32
+	minHeight, maxHeight int64
+	lessFn               func(bi, bj *CachedBlock) bool
+}
+
+func NewBlockPriorityQueue(capacity uint32) *BlockPriorityQueue {
+	pq := &BlockPriorityQueue{
+		bh:        blockHeap{},
+		capacity:  capacity,
+		minHeight: math.MaxUint32,
+		maxHeight: -1,
+	}
+	pq.SetLessFn(LessByAccessCountThenHeight)
+	return pq
+}
+
+func (pq BlockPriorityQueue) Len() int {
+	return len(pq.bh)
+}
+
+func (pq BlockPriorityQueue) Less(i, j int) bool {
+	return pq.lessFn(pq.bh[i], pq.bh[j])
+}
+
+func (pq *BlockPriorityQueue) SetLessFn(lessFn func(bi, bj *CachedBlock) bool) {
+	pq.lessFn = lessFn
+}
+
+func LessByAccessCountThenHeight(bi, bj *CachedBlock) bool {
+	if bi.accesses == bj.accesses {
+		return LessByHeight(bi, bj)
+	}
+	return LessByAccessCount(bi, bj)
+}
+
+func LessByHeight(bi, bj *CachedBlock) bool {
+	return bi.summary.Height < bj.summary.Height
+}
+
+func LessByAccessCount(bi, bj *CachedBlock) bool {
+	return bi.accesses < bj.accesses
+}
+
+func LessByAccessTime(bi, bj *CachedBlock) bool {
+	return bi.accessTime < bj.accessTime
+}
+
+func MakeLessByAccessTimeThenCount(secondsBinned int64) func(bi, bj *CachedBlock) bool {
+	nanosecondThreshold := time.Duration(secondsBinned) * time.Second
+	return func(bi, bj *CachedBlock) bool {
+		epochDiff := (bi.accessTime - bj.accessTime) / int64(nanosecondThreshold)
+		if epochDiff < 0 {
+			return true
+		}
+		return LessByAccessCount(bi, bj)
+	}
+}
+
+func GreaterByAccessCountThenHeight(bi, bj *CachedBlock) bool {
+	if bi.accesses == bj.accesses {
+		return GreaterByHeight(bi, bj)
+	}
+	return GreaterByAccessCount(bi, bj)
+}
+
+func GreaterByHeight(bi, bj *CachedBlock) bool {
+	return bi.summary.Height > bj.summary.Height
+}
+
+func GreaterByAccessCount(bi, bj *CachedBlock) bool {
+	return bi.accesses > bj.accesses
+}
+
+func (pq BlockPriorityQueue) Swap(i, j int) {
+	pq.bh[i], pq.bh[j] = pq.bh[j], pq.bh[i]
+	pq.bh[i].heapIdx = i
+	pq.bh[j].heapIdx = j
+}
+
+// Push a *BlockDataBasic
+func (pq *BlockPriorityQueue) Push(blockSummary interface{}) {
+	b := &CachedBlock{
+		summary:    blockSummary.(*BlockDataBasic),
+		accesses:   1,
+		accessTime: time.Now().UnixNano(),
+		heapIdx:    len(pq.bh),
+	}
+	pq.updateMinMax(b.summary.Height)
+	pq.bh = append(pq.bh, b)
+}
+
+// Pop will return an interface{} that may be cast to *CachedBlock
+func (pq *BlockPriorityQueue) Pop() interface{} {
+	n := pq.Len()
+	old := pq.bh
+	block := old[n-1]
+	block.heapIdx = -1
+	pq.bh = old[0 : n-1]
+	return block
+}
+
+func (pq *BlockPriorityQueue) ResetHeap(bh []*CachedBlock) {
+	pq.maxHeight = -1
+	pq.minHeight = math.MaxUint32
+	now := time.Now().UnixNano()
+	for i := range bh {
+		pq.updateMinMax(bh[i].summary.Height)
+		bh[i].heapIdx = i
+		bh[i].accesses = 1
+		bh[i].accessTime = now
+	}
+	//pq.bh = bh
+	pq.bh = make([]*CachedBlock, len(bh))
+	copy(pq.bh, bh)
+	pq.Reheap()
+}
+
+func (pq *BlockPriorityQueue) Reheap() {
+	heap.Init(pq)
+}
+
+// Insert will add an element, while respecting the queue's capacity
+// if at capacity
+// 		- compare with top and replace or return
+// 		- if replaced top, heapdown (Fix(pq,0))
+// else (not at capacity)
+// 		- heap.Push, which is pq.Push (append at bottom) then heapup
+func (pq *BlockPriorityQueue) Insert(summary *BlockDataBasic) {
+	if pq.capacity == 0 {
+		return
+	}
+
+	cachedBlock := &CachedBlock{
+		summary:    summary,
+		accesses:   1,
+		accessTime: time.Now().UnixNano(),
+	}
+
+	// At capacity
+	if int(pq.capacity) == pq.Len() {
+		// If new block not lower priority than next to pop, replace that in the
+		// queue and fix up the heap.
+		if pq.lessFn(pq.bh[0], cachedBlock) {
+			cachedBlock.heapIdx = 0
+			pq.bh[0] = cachedBlock
+			heap.Fix(pq, 0)
+		}
+		// otherwise this block doesn't qualify
+		return
+	}
+
+	// With room to grow, append at bottom and bubble up
+	heap.Push(pq, summary)
+}
+
+func (pq *BlockPriorityQueue) UpdateBlock(b *CachedBlock, summary *BlockDataBasic) {
+	if b != nil {
+		b.summary = summary
+		pq.updateMinMax(b.summary.Height)
+		heap.Fix(pq, b.heapIdx)
+	}
+}
+
+func (pq *BlockPriorityQueue) RemoveBlock(b *CachedBlock) {
+	if b != nil && b.heapIdx > 0 && b.heapIdx < pq.Len() {
+		pq.RemoveIndex(b.heapIdx)
+	}
+}
+
+func (pq *BlockPriorityQueue) RemoveIndex(idx int) {
+	heap.Remove(pq, idx)
+	pq.RescanMinMax()
+}
+
+func (pq *BlockPriorityQueue) RescanMinMax() {
+	for i := range pq.bh {
+		pq.updateMinMax(pq.bh[i].summary.Height)
+	}
+}
+
+func (pq *BlockPriorityQueue) updateMinMax(h uint32) {
+	if int64(h) > pq.maxHeight {
+		pq.maxHeight = int64(h)
+	}
+	if int64(h) < pq.minHeight {
+		pq.minHeight = int64(h)
+	}
+}

--- a/dcrdataapi/apicache.go
+++ b/dcrdataapi/apicache.go
@@ -88,6 +88,8 @@ func (apic *APICache) UtilizationBlocks() int64 { return int64(len(apic.blockCac
 
 // Utilization returns the percent utilization of the cache
 func (apic *APICache) Utilization() float64 {
+	apic.RLock()
+	defer apic.RUnlock()
 	return 100.0 * float64(len(apic.blockCache)) / float64(apic.capacity)
 }
 
@@ -149,8 +151,8 @@ func (apic *APICache) StoreBlockSummary(blockSummary *BlockDataBasic) error {
 // RemoveCachedBlock removes the input CachedBlock the cache. If the block is
 // not in cache, this is essentially a silent no-op.
 func (apic *APICache) RemoveCachedBlock(cachedBlock *CachedBlock) {
-	apic.RLock()
-	defer apic.RUnlock()
+	apic.Lock()
+	defer apic.Unlock()
 	// remove the block from the expiration queue
 	apic.expireQueue.RemoveBlock(cachedBlock)
 	// remove from block cache
@@ -210,8 +212,8 @@ func (apic *APICache) GetCachedBlockByHash(hash chainhash.Hash) *CachedBlock {
 // and increment the block's access count.
 func (apic *APICache) getCachedBlockByHash(hash chainhash.Hash) *CachedBlock {
 
-	apic.RLock()
-	defer apic.RUnlock()
+	apic.Lock()
+	defer apic.Unlock()
 
 	cachedBlock, ok := apic.blockCache[hash]
 	if ok {

--- a/dcrdataapi/apicache_test.go
+++ b/dcrdataapi/apicache_test.go
@@ -1,0 +1,65 @@
+package dcrdataapi
+
+import (
+	"container/heap"
+	"testing"
+)
+
+// constants from time
+const (
+	secondsPerMinute int64 = 60
+	secondsPerHour   int64 = 60 * 60
+	secondsPerDay    int64 = 24 * secondsPerHour
+	secondsPerWeek   int64 = 7 * secondsPerDay
+)
+
+// TODO: Make a proper test rather than a playground
+
+func TestBlockPriorityQueue(t *testing.T) {
+	pq := NewBlockPriorityQueue(5)
+	//pq.SetLessFn(LessByAccessCountThenHeight)
+	//pq.SetLessFn(LessByAccessCount)
+	//pq.SetLessFn(LessByAccessTime)
+	//pq.SetLessFn(LessByHeight)
+	pq.SetLessFn(MakeLessByAccessTimeThenCount(secondsPerDay))
+
+	cachedBlocks := []*CachedBlock{
+		NewCachedBlock(&BlockDataBasic{
+			Height: 123,
+		}),
+		NewCachedBlock(&BlockDataBasic{
+			Height: 1000,
+		}),
+		NewCachedBlock(&BlockDataBasic{
+			Height: 1,
+		}),
+		NewCachedBlock(&BlockDataBasic{
+			Height: 400,
+		}),
+	}
+
+	// reheap, which resets all access counts and times
+	pq.ResetHeap(cachedBlocks)
+
+	// forge the access counts
+	cachedBlocks[0].accesses = 1
+	cachedBlocks[1].accesses = 2
+	cachedBlocks[2].accesses = 10
+	cachedBlocks[3].accesses = 4
+	heap.Init(pq)
+
+	t.Log(pq.capacity, pq.Len(), pq.minHeight, pq.maxHeight)
+
+	// heap.Push(pq, &BlockDataBasic{Height: 1001})
+	pq.Insert(&BlockDataBasic{Height: 1001})
+	// heap.Push(pq, &BlockDataBasic{Height: 1002})
+	pq.Insert(&BlockDataBasic{Height: 0})
+	pq.Insert(&BlockDataBasic{Height: 6})
+
+	for pq.Len() > 0 {
+		cachedBlock := heap.Pop(pq).(*CachedBlock)
+		t.Logf("%8d\t%4d\t%d\t%4d\n", cachedBlock.summary.Height, cachedBlock.accesses, cachedBlock.accessTime, pq.Len())
+	}
+
+	heap.Push(pq, &BlockDataBasic{Height: 1})
+}

--- a/dcrdataapi/apicache_test.go
+++ b/dcrdataapi/apicache_test.go
@@ -5,14 +5,6 @@ import (
 	"testing"
 )
 
-// constants from time
-const (
-	secondsPerMinute int64 = 60
-	secondsPerHour   int64 = 60 * 60
-	secondsPerDay    int64 = 24 * secondsPerHour
-	secondsPerWeek   int64 = 7 * secondsPerDay
-)
-
 // TODO: Make a proper test rather than a playground
 
 func TestBlockPriorityQueue(t *testing.T) {
@@ -21,19 +13,19 @@ func TestBlockPriorityQueue(t *testing.T) {
 	//pq.SetLessFn(LessByAccessCount)
 	//pq.SetLessFn(LessByAccessTime)
 	//pq.SetLessFn(LessByHeight)
-	pq.SetLessFn(MakeLessByAccessTimeThenCount(secondsPerDay))
+	pq.SetLessFn(MakeLessByAccessTimeThenCount(SecondsPerDay))
 
 	cachedBlocks := []*CachedBlock{
-		NewCachedBlock(&BlockDataBasic{
+		newCachedBlock(&BlockDataBasic{
 			Height: 123,
 		}),
-		NewCachedBlock(&BlockDataBasic{
+		newCachedBlock(&BlockDataBasic{
 			Height: 1000,
 		}),
-		NewCachedBlock(&BlockDataBasic{
+		newCachedBlock(&BlockDataBasic{
 			Height: 1,
 		}),
-		NewCachedBlock(&BlockDataBasic{
+		newCachedBlock(&BlockDataBasic{
 			Height: 400,
 		}),
 	}

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -518,7 +518,7 @@ func (db *wiredDB) GetSummary(idx int) *apitypes.BlockDataBasic {
 		if err = db.APICache.StoreBlockSummary(blockSummary); err != nil {
 			log.Warnf("Unable to store block summary in APICache: %v", err)
 		} else {
-			log.Debugf("Stored block in cache: %d / %v. Utilization: %v%%",
+			log.Tracef("Stored block in cache: %d / %v. Utilization: %v%%",
 				blockSummary.Height, blockSummary.Hash, db.APICache.Utilization())
 		}
 	}

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -89,7 +89,7 @@ func (db *wiredDB) buildMainchainBlockMap() error {
 
 	dbHeight := db.dbSummaryHeight
 
-	db.APICache.MainchainBlocks = make([]chainhash.Hash, 0, dbHeight)
+	db.APICache.MainchainBlocks = make([]chainhash.Hash, 0, dbHeight+20000)
 
 	for i := int64(0); i <= dbHeight; i++ {
 		hashStr, err := db.RetrieveBlockHash(i)

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -22,19 +22,26 @@ import (
 	"github.com/decred/dcrutil"
 )
 
+type BlockSummarySaver interface {
+	StoreBlockSummary(blockSummary *apitypes.BlockDataBasic) error
+}
+
 // wiredDB is intended to satisfy APIDataSource interface. The block header is
 // not stored in the DB, so the RPC client is used to get it on demand.
 type wiredDB struct {
 	*DBDataSaver
-	MPC    *mempool.MempoolDataCache
-	client *dcrrpcclient.Client
-	params *chaincfg.Params
-	sDB    *stakedb.StakeDatabase
+	APICache *apitypes.APICache
+	MPC      *mempool.MempoolDataCache
+	client   *dcrrpcclient.Client
+	params   *chaincfg.Params
+	sDB      *stakedb.StakeDatabase
 }
 
 func newWiredDB(DB *DB, statusC chan uint32, cl *dcrrpcclient.Client, p *chaincfg.Params) (wiredDB, func() error) {
+	apic := apitypes.NewAPICache(50000)
 	wDB := wiredDB{
-		DBDataSaver: &DBDataSaver{DB, statusC},
+		DBDataSaver: &DBDataSaver{DB, statusC, apic},
+		APICache:    apic,
 		MPC:         new(mempool.MempoolDataCache),
 		client:      cl,
 		params:      p,
@@ -47,6 +54,12 @@ func newWiredDB(DB *DB, statusC chan uint32, cl *dcrrpcclient.Client, p *chaincf
 		log.Errorf("Unable to create stake DB: %v", err)
 		return wDB, func() error { return nil }
 	}
+
+	log.Info("Generating main chain block map...")
+	if err = wDB.buildMainchainBlockMap(); err != nil {
+		panic(fmt.Sprintf("Unable to build mainchain block map: %v", err))
+	}
+
 	return wDB, wDB.sDB.StakeDB.Close
 }
 
@@ -67,6 +80,34 @@ func InitWiredDB(dbInfo *DBInfo, statusC chan uint32, cl *dcrrpcclient.Client, p
 
 	wDB, cleanup := newWiredDB(db, statusC, cl, p)
 	return wDB, cleanup, nil
+}
+
+func (db *wiredDB) buildMainchainBlockMap() error {
+	if db.APICache == nil {
+		return fmt.Errorf("API cache disabled, unable to build MainchainBlock map")
+	}
+
+	dbHeight := db.dbSummaryHeight
+
+	db.APICache.MainchainBlocks = make([]chainhash.Hash, 0, dbHeight)
+
+	for i := int64(0); i <= dbHeight; i++ {
+		hashStr, err := db.RetrieveBlockHash(i)
+		if err != nil {
+			log.Errorf("Unable to get block hash for index %d: %v", i, err)
+			return err
+		}
+
+		hash, err := chainhash.NewHashFromStr(hashStr)
+		if err != nil {
+			log.Errorf("Invalid hash (%s) stored in DB for index %d: %v", hashStr, i, err)
+			return err
+		}
+
+		db.APICache.MainchainBlocks = append(db.APICache.MainchainBlocks, *hash)
+	}
+
+	return nil
 }
 
 func (db *wiredDB) NewStakeDBChainMonitor(quit chan struct{}, wg *sync.WaitGroup,
@@ -415,6 +456,16 @@ func (db *wiredDB) GetVoteInfo(txid string) (*apitypes.VoteInfo, error) {
 	return vinfo, nil
 }
 
+func (db *wiredDB) GetHash(idx int64) (string, error) {
+	hash, err := db.RetrieveBlockHash(idx)
+	if err != nil {
+		log.Errorf("Unable to block hash for index %d: %v", idx, err)
+		return "", err
+	}
+
+	return hash, nil
+}
+
 func (db *wiredDB) GetStakeDiffEstimates() *apitypes.StakeDiff {
 	sd := rpcutils.GetStakeDiffEstimates(db.client)
 
@@ -447,10 +498,29 @@ func (db *wiredDB) GetStakeInfoExtended(idx int) *apitypes.StakeInfoExtended {
 }
 
 func (db *wiredDB) GetSummary(idx int) *apitypes.BlockDataBasic {
-	blockSummary, err := db.RetrieveBlockSummary(int64(idx))
+	var blockSummary *apitypes.BlockDataBasic
+
+	if db.APICache != nil {
+		blockSummary = db.APICache.GetBlockSummary(int64(idx))
+		if blockSummary != nil {
+			return blockSummary
+		}
+	}
+
+	var err error
+	blockSummary, err = db.RetrieveBlockSummary(int64(idx))
 	if err != nil {
 		log.Errorf("Unable to retrieve block summary: %v", err)
 		return nil
+	}
+
+	if db.APICache != nil {
+		if err = db.APICache.StoreBlockSummary(blockSummary); err != nil {
+			log.Warnf("Unable to store block summary in APICache: %v", err)
+		} else {
+			log.Debugf("Stored block in cache: %d / %v. Utilization: %v%%",
+				blockSummary.Height, blockSummary.Hash, db.APICache.Utilization())
+		}
 	}
 
 	return blockSummary

--- a/dcrsqlite/chainmonitor.go
+++ b/dcrsqlite/chainmonitor.go
@@ -185,6 +185,23 @@ func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 			log.Error("Failed to collect data for reorg.")
 			continue
 		}
+		// Cache
+		if p.db.APICache != nil {
+			// If a block was cached at this height already, it was from the
+			// previous mainchain, so remove it.
+			height := int64(blockDataSummary.Height)
+			if cachedBlock := p.db.APICache.GetCachedBlockByHeight(height); cachedBlock != nil {
+				p.db.APICache.RemoveCachedBlock(cachedBlock)
+			}
+			// Store block summary in a new cached block
+			if err := p.db.APICache.StoreBlockSummary(blockDataSummary); err != nil {
+				log.Warn("Unable to store block summary in cache:", err)
+			} else {
+				log.Debugf("Stored block in cache: %d / %v. Utilization: %v%%",
+					blockDataSummary.Height, blockDataSummary.Hash, p.db.APICache.Utilization())
+			}
+		}
+		// DB
 		if err := p.db.StoreBlockSummary(blockDataSummary); err != nil {
 			log.Errorf("Failed to store block summary data: %v", err)
 		}

--- a/dcrsqlite/sqlite.go
+++ b/dcrsqlite/sqlite.go
@@ -198,6 +198,9 @@ func (db *DBDataSaver) Store(data *blockdata.BlockData) error {
 			log.Debugf("Stored block in cache: %d / %v. Utilization: %v%%",
 				summary.Height, summary.Hash, utilization)
 		}
+		hits := db.cache.(*apitypes.APICache).Hits()
+		misses := db.cache.(*apitypes.APICache).Misses()
+		log.Debugf("Cache hits: %d, misses: %d", hits, misses)
 	}
 
 	select {

--- a/dcrsqlite/sync.go
+++ b/dcrsqlite/sync.go
@@ -92,7 +92,7 @@ func (db *wiredDB) resyncDB(quit chan struct{}) error {
 			},
 		}
 
-		freeCache := int64(db.APICache.Capacity()) - db.APICache.Utilization()
+		freeCache := int64(db.APICache.Capacity()) - db.APICache.UtilizationBlocks()
 		remainingBlocks := i - height
 		if db.APICache != nil && remainingBlocks <= freeCache {
 			if err = db.APICache.StoreBlockSummary(&blockSummary); err != nil {


### PR DESCRIPTION
The small change here is changing how the response to a block range API request is written to the `http.ResponseWriter`.  Previously, the entire marshalled JSON response had to be generated, which involved all the DB retrievals, prior to sending to the client.  Now the response is streamed as the blocks are retrieved and marshalled.  Newly-enabled zip compression complements the streaming response very well as the added latency is hidden, and bandwidth is drastically reduced allowing the full response to reach the client quickly.

The larger change in this PR is the addition of a cache for accessed blocks, `APICache`.  Access of a given block includes API requests for the block, or the addition of a new block to the cache via one of the chain monitors.

The capacity of the cache is specified in the number of blocks it should be able to hold before evicting low priority (I'll get to priority in a sec) blocks.  This is currently hard-coded to 50000, but it may be converted to a config parameter in the future.  `CachedBlock` represents a cached block, and it comprises a `BlockDataBasic` and fields for tracking access count, access time, and heap position index.  Within the `APICache` is a map APICacheof block hashes to `CachedBlock`s, and a priority queue `BlockPriorityQueue` for the `CachedBlock`s stored by `APICache`, which facilitates evicting certain blocks as needed.

This can be improved a lot, but this is enough to start testing on the interwebs.

Version bumped to 0.6.2.