### PR TITLE
Block verbose and block-by-hash

### DIFF
--- a/apimiddleware.go
+++ b/apimiddleware.go
@@ -98,6 +98,48 @@ func (c *appContext) BlockIndexLatestCtx(next http.Handler) http.Handler {
 	})
 }
 
+func (c *appContext) BlockHashLatestCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := -1
+		hash := ""
+		if c.BlockData != nil {
+			var err error
+			// if hash, err = c.BlockData.GetBestBlockHash(int64(idx)); err != nil {
+			// 	apiLog.Errorf("Unable to GetBestBlockHash: %v", idx, err)
+			// }
+			if idx = c.BlockData.GetHeight(); idx >= 0 {
+				if hash, err = c.BlockData.GetBlockHash(int64(idx)); err != nil {
+					apiLog.Errorf("Unable to GetBlockHash(%d): %v", idx, err)
+				}
+			}
+		}
+		ctx := context.WithValue(r.Context(), ctxBlockIndex, idx)
+		ctx = context.WithValue(ctx, ctxBlockHash, hash)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func BlockHashPathCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hash := chi.URLParam(r, "blockhash")
+		ctx := context.WithValue(r.Context(), ctxBlockHash, hash)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func (c *appContext) BlockHashPathAndIndexCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hash := chi.URLParam(r, "blockhash")
+		height, err := c.BlockData.GetBlockHeight(hash)
+		if err != nil {
+			apiLog.Errorf("Unable to GetBlockHeight(%d): %v", height, err)
+		}
+		ctx := context.WithValue(r.Context(), ctxBlockHash, hash)
+		ctx = context.WithValue(ctx, ctxBlockIndex, height)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
 // apiDocs generates a middleware with a "docs" in the context containing a
 // map of the routers handlers, etc.
 func apiDocs(mux *chi.Mux) func(next http.Handler) http.Handler {

--- a/apimiddleware.go
+++ b/apimiddleware.go
@@ -21,6 +21,7 @@ const (
 	ctxAPIStatus
 	ctxBlockIndex0
 	ctxBlockIndex
+	ctxBlockHash
 	ctxN
 )
 

--- a/apirouter.go
+++ b/apirouter.go
@@ -39,6 +39,7 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Get("/", app.getBlockSummary) // app.getLatestBlock
 			rd.Get("/height", app.currentHeight)
 			rd.Get("/header", app.getBlockHeader)
+			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
 		})
 
@@ -46,6 +47,7 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Use(BlockIndexPathCtx)
 			rd.Get("/", app.getBlockSummary)
 			rd.Get("/header", app.getBlockHeader)
+			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
 		})
 

--- a/apirouter.go
+++ b/apirouter.go
@@ -38,6 +38,16 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Use(app.BlockIndexLatestCtx)
 			rd.Get("/", app.getBlockSummary) // app.getLatestBlock
 			rd.Get("/height", app.currentHeight)
+			rd.Get("/hash", app.getBlockHash)
+			rd.Get("/header", app.getBlockHeader)
+			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
+			rd.Get("/pos", app.getBlockStakeInfoExtended)
+		})
+
+		r.Route("/hash/{blockhash}", func(rd chi.Router) {
+			rd.Use(app.BlockHashPathAndIndexCtx)
+			rd.Get("/", app.getBlockSummary)
+			rd.Get("/height", app.getBlockHeight)
 			rd.Get("/header", app.getBlockHeader)
 			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
@@ -47,6 +57,7 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Use(BlockIndexPathCtx)
 			rd.Get("/", app.getBlockSummary)
 			rd.Get("/header", app.getBlockHeader)
+			rd.Get("/hash", app.getBlockHash)
 			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
 		})

--- a/apirouter.go
+++ b/apirouter.go
@@ -42,6 +42,9 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Get("/header", app.getBlockHeader)
 			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
+			rd.Route("/tx", func(rt chi.Router) {
+				rt.Get("/", app.getBlockTransactions)
+			})
 		})
 
 		r.Route("/hash/{blockhash}", func(rd chi.Router) {
@@ -51,6 +54,9 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Get("/header", app.getBlockHeader)
 			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
+			rd.Route("/tx", func(rt chi.Router) {
+				rt.Get("/", app.getBlockTransactions)
+			})
 		})
 
 		r.Route("/{idx}", func(rd chi.Router) {
@@ -60,6 +66,9 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Get("/hash", app.getBlockHash)
 			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
+			rd.Route("/tx", func(rt chi.Router) {
+				rt.Get("/", app.getBlockTransactions)
+			})
 		})
 
 		r.Route("/range/{idx0}/{idx}", func(rd chi.Router) {

--- a/apiroutes.go
+++ b/apiroutes.go
@@ -15,8 +15,10 @@ import (
 
 type APIDataSource interface {
 	GetHeight() int
+	GetHash(idx int64) (string, error)
 	//Get(idx int) *blockdata.BlockData
 	GetHeader(idx int) *dcrjson.GetBlockHeaderVerboseResult
+	GetBlockVerbose(idx int) *dcrjson.GetBlockVerboseResult
 	GetFeeInfo(idx int) *dcrjson.FeeInfoBlock
 	//GetStakeDiffEstimate(idx int) *dcrjson.EstimateStakeDiffResult
 	GetStakeInfoExtended(idx int) *apitypes.StakeInfoExtended
@@ -245,6 +247,21 @@ func (c *appContext) getBlockHeader(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, blockHeader, c.getIndentQuery(r))
+}
+
+func (c *appContext) getBlockVerbose(w http.ResponseWriter, r *http.Request) {
+	idx := getBlockIndexCtx(r)
+	if idx < 0 {
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+
+	blockVerbose := c.BlockData.GetBlockVerbose(idx)
+	if blockVerbose == nil {
+		apiLog.Errorf("Unable to get block %d", idx)
+	}
+
+	writeJSON(w, blockVerbose, c.getIndentQuery(r))
 }
 
 func (c *appContext) getBlockFeeInfo(w http.ResponseWriter, r *http.Request) {

--- a/apiroutes.go
+++ b/apiroutes.go
@@ -165,7 +165,7 @@ func getBlockIndex0Ctx(r *http.Request) int {
 func getBlockHashOnlyCtx(r *http.Request) string {
 	hash, ok := r.Context().Value(ctxBlockHash).(string)
 	if !ok {
-		apiLog.Error("block hash not set")
+		apiLog.Trace("block hash not set")
 		return ""
 	}
 	return hash

--- a/apiroutes.go
+++ b/apiroutes.go
@@ -22,6 +22,8 @@ type APIDataSource interface {
 	GetHeader(idx int) *dcrjson.GetBlockHeaderVerboseResult
 	GetBlockVerbose(idx int, verboseTx bool) *dcrjson.GetBlockVerboseResult
 	GetBlockVerboseByHash(hash string, verboseTx bool) *dcrjson.GetBlockVerboseResult
+	GetTransactionsForBlock(idx int64) *apitypes.BlockTransactions
+	GetTransactionsForBlockByHash(hash string) *apitypes.BlockTransactions
 	GetFeeInfo(idx int) *dcrjson.FeeInfoBlock
 	//GetStakeDiffEstimate(idx int) *dcrjson.EstimateStakeDiffResult
 	GetStakeInfoExtended(idx int) *apitypes.StakeInfoExtended
@@ -290,6 +292,20 @@ func (c *appContext) getBlockSummary(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, blockSummary, c.getIndentQuery(r))
+}
+
+func (c *appContext) getBlockTransactions(w http.ResponseWriter, r *http.Request) {
+	hash := c.getBlockHashCtx(r)
+	if hash == "" {
+		http.Error(w, http.StatusText(422), 422)
+	}
+
+	blockTransactions := c.BlockData.GetTransactionsForBlockByHash(hash)
+	if blockTransactions == nil {
+		apiLog.Errorf("Unable to get block %s summary", hash)
+	}
+
+	writeJSON(w, blockTransactions, c.getIndentQuery(r))
 }
 
 func (c *appContext) getBlockHeader(w http.ResponseWriter, r *http.Request) {

--- a/apiroutes.go
+++ b/apiroutes.go
@@ -18,7 +18,7 @@ type APIDataSource interface {
 	GetHash(idx int64) (string, error)
 	//Get(idx int) *blockdata.BlockData
 	GetHeader(idx int) *dcrjson.GetBlockHeaderVerboseResult
-	GetBlockVerbose(idx int) *dcrjson.GetBlockVerboseResult
+	GetBlockVerbose(idx int, verboseTx bool) *dcrjson.GetBlockVerboseResult
 	GetFeeInfo(idx int) *dcrjson.FeeInfoBlock
 	//GetStakeDiffEstimate(idx int) *dcrjson.EstimateStakeDiffResult
 	GetStakeInfoExtended(idx int) *apitypes.StakeInfoExtended
@@ -256,7 +256,7 @@ func (c *appContext) getBlockVerbose(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	blockVerbose := c.BlockData.GetBlockVerbose(idx)
+	blockVerbose := c.BlockData.GetBlockVerbose(idx, false)
 	if blockVerbose == nil {
 		apiLog.Errorf("Unable to get block %d", idx)
 	}

--- a/dcrdataapi/apitypes.go
+++ b/dcrdataapi/apitypes.go
@@ -10,6 +10,11 @@ import (
 // much of the time, dcrdata will be using the types in dcrjson, but others are
 // defined here
 
+type BlockTransactions struct {
+	Tx  []string `json:"tx"`
+	STx []string `json:"stx"`
+}
+
 // Status indicates the state of the server, including the API version and the
 // software version.
 type Status struct {

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -116,8 +116,8 @@ func (db *wiredDB) GetHeader(idx int) *dcrjson.GetBlockHeaderVerboseResult {
 	return rpcutils.GetBlockHeaderVerbose(db.client, db.params, int64(idx))
 }
 
-func (db *wiredDB) GetBlockVerbose(idx int) *dcrjson.GetBlockVerboseResult {
-	return rpcutils.GetBlockVerbose(db.client, db.params, int64(idx))
+func (db *wiredDB) GetBlockVerbose(idx int, verboseTx bool) *dcrjson.GetBlockVerboseResult {
+	return rpcutils.GetBlockVerbose(db.client, db.params, int64(idx), verboseTx)
 }
 
 func (db *wiredDB) GetStakeDiffEstimates() *apitypes.StakeDiff {

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -98,12 +98,26 @@ func (db *wiredDB) GetStakeDB() *stakedb.StakeDatabase {
 	return db.sDB
 }
 
+// TODO: Update this to use RetrieveBlockHeight
 func (db *wiredDB) GetHeight() int {
 	return int(db.GetBlockSummaryHeight())
 }
 
+func (db *wiredDB) GetHash(idx int64) (string, error) {
+	hash, err := db.RetrieveBlockHash(idx)
+	if err != nil {
+		log.Errorf("Unable to block hash for index %d: %v", idx, err)
+		return "", err
+	}
+	return hash, nil
+}
+
 func (db *wiredDB) GetHeader(idx int) *dcrjson.GetBlockHeaderVerboseResult {
 	return rpcutils.GetBlockHeaderVerbose(db.client, db.params, int64(idx))
+}
+
+func (db *wiredDB) GetBlockVerbose(idx int) *dcrjson.GetBlockVerboseResult {
+	return rpcutils.GetBlockVerbose(db.client, db.params, int64(idx))
 }
 
 func (db *wiredDB) GetStakeDiffEstimates() *apitypes.StakeDiff {

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -142,6 +142,30 @@ func (db *wiredDB) GetBlockVerboseByHash(hash string, verboseTx bool) *dcrjson.G
 	return rpcutils.GetBlockVerboseByHash(db.client, db.params, hash, verboseTx)
 }
 
+func (db *wiredDB) GetTransactionsForBlock(idx int64) *apitypes.BlockTransactions {
+	blockVerbose := rpcutils.GetBlockVerbose(db.client, db.params, idx, false)
+
+	return makeBlockTransactions(blockVerbose)
+}
+
+func (db *wiredDB) GetTransactionsForBlockByHash(hash string) *apitypes.BlockTransactions {
+	blockVerbose := rpcutils.GetBlockVerboseByHash(db.client, db.params, hash, false)
+
+	return makeBlockTransactions(blockVerbose)
+}
+
+func makeBlockTransactions(blockVerbose *dcrjson.GetBlockVerboseResult) *apitypes.BlockTransactions {
+	blockTransactions := new(apitypes.BlockTransactions)
+
+	blockTransactions.Tx = make([]string, len(blockVerbose.Tx))
+	copy(blockTransactions.Tx, blockVerbose.Tx)
+
+	blockTransactions.STx = make([]string, len(blockVerbose.STx))
+	copy(blockTransactions.STx, blockVerbose.STx)
+
+	return blockTransactions
+}
+
 func (db *wiredDB) GetStakeDiffEstimates() *apitypes.StakeDiff {
 	sd := rpcutils.GetStakeDiffEstimates(db.client)
 

--- a/dcrsqlite/sqlite.go
+++ b/dcrsqlite/sqlite.go
@@ -51,6 +51,7 @@ type DB struct {
 	getLatestBlockSQL                                   string
 	getBlockSQL, insertBlockSQL                         string
 	getBlockHashSQL, getBlockHeightSQL                  string
+	getBestBlockHashSQL, getBestBlockHeightSQL          string
 	getLatestStakeInfoExtendedSQL                       string
 	getStakeInfoExtendedSQL, insertStakeInfoExtendedSQL string
 }
@@ -86,6 +87,9 @@ func NewDB(db *sql.DB) *DB {
             height, size, hash, diff, sdiff, time, poolsize, poolval, poolavg
         ) values(?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, TableNameSummaries)
+
+	d.getBestBlockHashSQL = fmt.Sprintf(`select hash from %s ORDER BY height DESC LIMIT 0, 1`, TableNameSummaries)
+	d.getBestBlockHeightSQL = fmt.Sprintf(`select height from %s ORDER BY height DESC LIMIT 0, 1`, TableNameSummaries)
 
 	d.getBlockHashSQL = fmt.Sprintf(`select hash from %s where height = ?`, TableNameSummaries)
 	d.getBlockHeightSQL = fmt.Sprintf(`select height from %s where hash = ?`, TableNameSummaries)
@@ -406,6 +410,18 @@ func (db *DB) RetrieveBlockHash(ind int64) (string, error) {
 func (db *DB) RetrieveBlockHeight(hash string) (int64, error) {
 	var blockHeight int64
 	err := db.QueryRow(db.getBlockHeightSQL, hash).Scan(&blockHeight)
+	return blockHeight, err
+}
+
+func (db *DB) RetrieveBestBlockHash() (string, error) {
+	var blockHash string
+	err := db.QueryRow(db.getBestBlockHashSQL).Scan(&blockHash)
+	return blockHash, err
+}
+
+func (db *DB) RetrieveBestBlockHeight() (int64, error) {
+	var blockHeight int64
+	err := db.QueryRow(db.getBestBlockHeightSQL).Scan(&blockHeight)
 	return blockHeight, err
 }
 

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -148,14 +148,14 @@ func GetBlockHeaderVerbose(client *dcrrpcclient.Client, params *chaincfg.Params,
 // GetBlockVerbose creates a *dcrjson.GetBlockVerboseResult for the block index
 // specified by idx via an RPC connection to a chain server.
 func GetBlockVerbose(client *dcrrpcclient.Client, params *chaincfg.Params,
-	idx int64) *dcrjson.GetBlockVerboseResult {
+	idx int64, verboseTx bool) *dcrjson.GetBlockVerboseResult {
 	blockhash, err := client.GetBlockHash(idx)
 	if err != nil {
 		log.Errorf("GetBlockHash(%d) failed: %v", idx, err)
 		return nil
 	}
 
-	blockVerbose, err := client.GetBlockVerbose(blockhash, true)
+	blockVerbose, err := client.GetBlockVerbose(blockhash, verboseTx)
 	if err != nil {
 		log.Errorf("GetBlockVerbose(%v) failed: %v", blockhash, err)
 		return nil

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -164,6 +164,25 @@ func GetBlockVerbose(client *dcrrpcclient.Client, params *chaincfg.Params,
 	return blockVerbose
 }
 
+// GetBlockVerboseByHash creates a *dcrjson.GetBlockVerboseResult for the
+// specified block hash via an RPC connection to a chain server.
+func GetBlockVerboseByHash(client *dcrrpcclient.Client, params *chaincfg.Params,
+	hash string, verboseTx bool) *dcrjson.GetBlockVerboseResult {
+	blockhash, err := chainhash.NewHashFromStr(hash)
+	if err != nil {
+		log.Errorf("Invalid block hash %s", hash)
+		return nil
+	}
+
+	blockVerbose, err := client.GetBlockVerbose(blockhash, verboseTx)
+	if err != nil {
+		log.Errorf("GetBlockVerbose(%v) failed: %v", blockhash, err)
+		return nil
+	}
+
+	return blockVerbose
+}
+
 // GetStakeDiffEstimates combines the results of EstimateStakeDiff and
 // GetStakeDifficulty into a *apitypes.StakeDiff.
 func GetStakeDiffEstimates(client *dcrrpcclient.Client) *apitypes.StakeDiff {

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -145,6 +145,25 @@ func GetBlockHeaderVerbose(client *dcrrpcclient.Client, params *chaincfg.Params,
 	return blockHeaderVerbose
 }
 
+// GetBlockVerbose creates a *dcrjson.GetBlockVerboseResult for the block index
+// specified by idx via an RPC connection to a chain server.
+func GetBlockVerbose(client *dcrrpcclient.Client, params *chaincfg.Params,
+	idx int64) *dcrjson.GetBlockVerboseResult {
+	blockhash, err := client.GetBlockHash(idx)
+	if err != nil {
+		log.Errorf("GetBlockHash(%d) failed: %v", idx, err)
+		return nil
+	}
+
+	blockVerbose, err := client.GetBlockVerbose(blockhash, true)
+	if err != nil {
+		log.Errorf("GetBlockVerbose(%v) failed: %v", blockhash, err)
+		return nil
+	}
+
+	return blockVerbose
+}
+
 // GetStakeDiffEstimates combines the results of EstimateStakeDiff and
 // GetStakeDifficulty into a *apitypes.StakeDiff.
 func GetStakeDiffEstimates(client *dcrrpcclient.Client) *apitypes.StakeDiff {


### PR DESCRIPTION
This PR primarily adds two new features:

1. Query for a "verbose" block data type, which includes arrays of transactions in the block, but not the expanded transaction details.  This corresponds to the output of `getrawtransaction [hash] verbose=true verbosetx=false`.
2. API endpoints to lookup data by block hash.  Previously it was just height, which made sense for querying ranges.

There are many other incidental changes to dcrsqlite and rpcutils.  In particular, dcrsqlite now has queries for hash by height, and height by hash.