### PR TITLE
Add block size endpoints, like /block/.../size.

### DIFF
--- a/apirouter.go
+++ b/apirouter.go
@@ -40,6 +40,7 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Get("/height", app.currentHeight)
 			rd.Get("/hash", app.getBlockHash)
 			rd.Get("/header", app.getBlockHeader)
+			rd.Get("/size", app.getBlockSize)
 			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
 			rd.Route("/tx", func(rt chi.Router) {
@@ -52,6 +53,7 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Get("/", app.getBlockSummary)
 			rd.Get("/height", app.getBlockHeight)
 			rd.Get("/header", app.getBlockHeader)
+			rd.Get("/size", app.getBlockSize)
 			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
 			rd.Route("/tx", func(rt chi.Router) {
@@ -64,6 +66,7 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Get("/", app.getBlockSummary)
 			rd.Get("/header", app.getBlockHeader)
 			rd.Get("/hash", app.getBlockHash)
+			rd.Get("/size", app.getBlockSize)
 			rd.With((middleware.Compress(1))).Get("/verbose", app.getBlockVerbose)
 			rd.Get("/pos", app.getBlockStakeInfoExtended)
 			rd.Route("/tx", func(rt chi.Router) {
@@ -75,6 +78,7 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 			rd.Use(BlockIndex0PathCtx, BlockIndexPathCtx)
 			rd.Use(middleware.Compress(1))
 			rd.Get("/", app.getBlockRangeSummary)
+			rd.Get("/size", app.getBlockRangeSize)
 			// rd.Get("/header", app.getBlockHeader)
 			// rd.Get("/pos", app.getBlockStakeInfoExtended)
 		})

--- a/apiroutes.go
+++ b/apiroutes.go
@@ -33,6 +33,8 @@ type APIDataSource interface {
 	GetSummary(idx int) *apitypes.BlockDataBasic
 	GetSummaryByHash(hash string) *apitypes.BlockDataBasic
 	GetBestBlockSummary() *apitypes.BlockDataBasic
+	GetBlockSize(idx int) (int32, error)
+	GetBlockSizeRange(idx0, idx1 int) ([]int32, error)
 	GetPoolInfo(idx int) *apitypes.TicketPoolInfo
 	GetPoolInfoByHash(hash string) *apitypes.TicketPoolInfo
 	GetPoolInfoRange(idx0, idx1 int) []apitypes.TicketPoolInfo
@@ -426,6 +428,44 @@ func (c *appContext) getSSTxDetails(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, sstxDetails, c.getIndentQuery(r))
+}
+
+func (c *appContext) getBlockSize(w http.ResponseWriter, r *http.Request) {
+	idx := c.getBlockHeightCtx(r)
+	if idx < 0 {
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+
+	blockSize, err := c.BlockData.GetBlockSize(int(idx))
+	if err != nil {
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+
+	writeJSON(w, blockSize, "")
+}
+
+func (c *appContext) getBlockRangeSize(w http.ResponseWriter, r *http.Request) {
+	idx0 := getBlockIndex0Ctx(r)
+	if idx0 < 0 {
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+
+	idx := getBlockIndexCtx(r)
+	if idx < 0 || idx < idx0 {
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+
+	blockSizes, err := c.BlockData.GetBlockSizeRange(idx0, idx)
+	if err != nil {
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+
+	writeJSON(w, blockSizes, "")
 }
 
 func (c *appContext) getBlockRangeSummary(w http.ResponseWriter, r *http.Request) {

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -228,6 +228,28 @@ func (db *wiredDB) GetBestBlockSummary() *apitypes.BlockDataBasic {
 	return blockSummary
 }
 
+func (db *wiredDB) GetBlockSize(idx int) (int32, error) {
+	blockSizes, err := db.RetrieveBlockSizeRange(int64(idx), int64(idx))
+	if err != nil {
+		log.Errorf("Unable to retrieve block %d size: %v", idx, err)
+		return -1, err
+	}
+	if len(blockSizes) == 0 {
+		log.Errorf("Unable to retrieve block %d size: %v", idx, err)
+		return -1, fmt.Errorf("empty block size slice")
+	}
+	return blockSizes[0], nil
+}
+
+func (db *wiredDB) GetBlockSizeRange(idx0, idx1 int) ([]int32, error) {
+	blockSizes, err := db.RetrieveBlockSizeRange(int64(idx0), int64(idx1))
+	if err != nil {
+		log.Errorf("Unable to retrieve block size range: %v", err)
+		return nil, err
+	}
+	return blockSizes, nil
+}
+
 func (db *wiredDB) GetPoolInfo(idx int) *apitypes.TicketPoolInfo {
 	ticketPoolInfo, err := db.RetrievePoolInfo(int64(idx))
 	if err != nil {


### PR DESCRIPTION
This includes range, where an array of integers is returned.

A new SQLite query is added to make this fast.  Only the size column is returned.

TODO: add transaction count somewhere, somehow.