### PR TITLE
Removed log warning

### DIFF
--- a/config.go
+++ b/config.go
@@ -274,8 +274,7 @@ func loadConfig() (*config, error) {
 	// succeeds.  This prevents the warning on help messages and invalid
 	// options.
 	if configFileError != nil {
-		//log.Warnf("%v", configFileError)
-		//fmt.Printf("%v\n",configFileError)
+		fmt.Printf("%v\n",configFileError)
 		return loadConfigError(configFileError)
 	}
 

--- a/config.go
+++ b/config.go
@@ -274,7 +274,7 @@ func loadConfig() (*config, error) {
 	// succeeds.  This prevents the warning on help messages and invalid
 	// options.
 	if configFileError != nil {
-		log.Warnf("%v", configFileError)
+		//log.Warnf("%v", configFileError)
 		//fmt.Printf("%v\n",configFileError)
 		return loadConfigError(configFileError)
 	}


### PR DESCRIPTION
In reference to issue #62, log.warnf seems to always have give a run time error but removing it should exit the app cleanly and still show the error