### PR TITLE
Mempool TxHandler efficiency

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -41,7 +41,6 @@ type mempoolMonitor struct {
 	newTxHash      chan *chainhash.Hash
 	quit           chan struct{}
 	wg             *sync.WaitGroup
-	mtx            sync.RWMutex
 }
 
 // NewMempoolMonitor creates a new mempoolMonitor
@@ -170,8 +169,6 @@ func (p *mempoolMonitor) TxHandler(client *dcrrpcclient.Client) {
 
 			// TODO: Get fee for this ticket (Vin[0] - Vout[0])
 
-			p.mtx.Lock()
-
 			// s.server.txMemPool.TxDescs()
 			ticketHashes, err := client.GetRawMempool(dcrjson.GRMTickets)
 			if err != nil {
@@ -221,7 +218,6 @@ func (p *mempoolMonitor) TxHandler(client *dcrrpcclient.Client) {
 				atomic.StoreInt32(&p.mpoolInfo.NumTicketsSinceStatsReport, 0)
 				// and timer
 				p.mpoolInfo.LastCollectTime = time.Now()
-				p.mtx.Unlock()
 				// Collect mempool data (currently ticket fees)
 				log.Trace("Gathering new mempool data.")
 				data, err = p.collector.Collect()
@@ -231,7 +227,6 @@ func (p *mempoolMonitor) TxHandler(client *dcrrpcclient.Client) {
 					continue
 				}
 			} else {
-				p.mtx.Unlock()
 				continue
 			}
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -204,15 +204,15 @@ func (p *mempoolMonitor) TxHandler(client *dcrrpcclient.Client) {
 			enoughNewTickets := newTickets >= p.newTicketLimit
 
 			timeSinceLast := time.Since(p.mpoolInfo.LastCollectTime)
-			if time.Since(s.T) > timeSinceLast {
-				log.Debugf("A Tx was queued before last mempool collection, which would have included it. SKIPPING.")
-				continue
-			}
 			quiteLong := timeSinceLast > p.maxInterval
 			longEnough := timeSinceLast >= p.minInterval
 
 			var data *MempoolData
 			if newBlock || quiteLong || (enoughNewTickets && longEnough) {
+				if time.Since(s.T) > timeSinceLast {
+					log.Debugf("A Tx was queued before last mempool collection, which would have included it. SKIPPING.")
+					continue
+				}
 				// reset counter for tickets since last report
 				p.mpoolInfo.NumTicketsSinceStatsReport = 0
 				// and timer

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	apitypes "github.com/dcrdata/dcrdata/dcrdataapi"
@@ -23,6 +22,11 @@ import (
 	"github.com/decred/dcrrpcclient"
 	"github.com/decred/dcrutil"
 )
+
+type NewTx struct {
+	Hash *chainhash.Hash
+	T    time.Time
+}
 
 type MempoolInfo struct {
 	CurrentHeight               uint32
@@ -38,14 +42,14 @@ type mempoolMonitor struct {
 	maxInterval    time.Duration
 	collector      *mempoolDataCollector
 	dataSavers     []MempoolDataSaver
-	newTxHash      chan *chainhash.Hash
+	newTxHash      chan *NewTx
 	quit           chan struct{}
 	wg             *sync.WaitGroup
 }
 
 // NewMempoolMonitor creates a new mempoolMonitor
 func NewMempoolMonitor(collector *mempoolDataCollector,
-	savers []MempoolDataSaver, newTxChan chan *chainhash.Hash,
+	savers []MempoolDataSaver, newTxChan chan *NewTx,
 	quit chan struct{}, wg *sync.WaitGroup, newTicketLimit int32,
 	mini time.Duration, maxi time.Duration, mpi *MempoolInfo) *mempoolMonitor {
 	return &mempoolMonitor{
@@ -104,15 +108,15 @@ func (p *mempoolMonitor) TxHandler(client *dcrrpcclient.Client) {
 			}
 
 			var err error
-			// oneTicket is 0 for a Ticker event or 1 for a ticket purchase Tx.
+			// oneTicket is 1 for a ticket purchase Tx or 0 for other tx types
 			var oneTicket int32
 			bestBlock := int64(-1)
 
 			// OnTxAccepted probably sent on newTxChan
-			tx, err := client.GetRawTransaction(s)
+			tx, err := client.GetRawTransaction(s.Hash)
 			if err != nil {
 				log.Errorf("Failed to get transaction (do you have --txindex with dcrd?) %v: %v",
-					s.String(), err)
+					s.Hash.String(), err)
 				continue
 			}
 
@@ -121,7 +125,7 @@ func (p *mempoolMonitor) TxHandler(client *dcrrpcclient.Client) {
 			txType := stake.DetermineTxType(tx.MsgTx())
 			//s.Tree() == dcrutil.TxTreeRegular
 			// See dcrd/blockchain/stake/staketx.go for information about
-			// specifications for different transaction types (TODO).
+			// specifications for different transaction types.
 
 			// Tx hash for either a current ticket purchase (SStx), or the
 			// original ticket purchase for a vote (SSGen).
@@ -169,14 +173,6 @@ func (p *mempoolMonitor) TxHandler(client *dcrrpcclient.Client) {
 
 			// TODO: Get fee for this ticket (Vin[0] - Vout[0])
 
-			// s.server.txMemPool.TxDescs()
-			ticketHashes, err := client.GetRawMempool(dcrjson.GRMTickets)
-			if err != nil {
-				log.Errorf("Could not get raw mempool: %v", err.Error())
-				continue
-			}
-			p.mpoolInfo.NumTicketPurchasesInMempool = uint32(len(ticketHashes))
-
 			// Decide if it is time to collect and record new data
 			// 1. Get block height
 			// 2. Record num new and total tickets in mp
@@ -198,24 +194,27 @@ func (p *mempoolMonitor) TxHandler(client *dcrrpcclient.Client) {
 			}
 			txHeight := uint32(bestBlock)
 
-			// Atomics really aren't necessary here because of mutex
 			newBlock := txHeight > p.mpoolInfo.CurrentHeight
-			enoughNewTickets := atomic.AddInt32(
-				&p.mpoolInfo.NumTicketsSinceStatsReport, oneTicket) >= p.newTicketLimit
-			timeSinceLast := time.Since(p.mpoolInfo.LastCollectTime)
-			quiteLong := timeSinceLast > p.maxInterval
-			longEnough := timeSinceLast >= p.minInterval
-
 			if newBlock {
-				atomic.StoreUint32(&p.mpoolInfo.CurrentHeight, txHeight)
+				p.mpoolInfo.CurrentHeight = txHeight
 			}
 
+			p.mpoolInfo.NumTicketsSinceStatsReport += oneTicket
 			newTickets := p.mpoolInfo.NumTicketsSinceStatsReport
+			enoughNewTickets := newTickets >= p.newTicketLimit
+
+			timeSinceLast := time.Since(p.mpoolInfo.LastCollectTime)
+			if time.Since(s.T) > timeSinceLast {
+				log.Debugf("A Tx was queued before last mempool collection, which would have included it. SKIPPING.")
+				continue
+			}
+			quiteLong := timeSinceLast > p.maxInterval
+			longEnough := timeSinceLast >= p.minInterval
 
 			var data *MempoolData
 			if newBlock || quiteLong || (enoughNewTickets && longEnough) {
 				// reset counter for tickets since last report
-				atomic.StoreInt32(&p.mpoolInfo.NumTicketsSinceStatsReport, 0)
+				p.mpoolInfo.NumTicketsSinceStatsReport = 0
 				// and timer
 				p.mpoolInfo.LastCollectTime = time.Now()
 				// Collect mempool data (currently ticket fees)
@@ -232,11 +231,11 @@ func (p *mempoolMonitor) TxHandler(client *dcrrpcclient.Client) {
 
 			// Insert new ticket counter into data structure
 			data.NewTickets = uint32(newTickets)
-			timestamp := time.Now()
 
-			//p.mpoolInfo.NumTicketPurchasesInMempool = data.ticketfees.FeeInfoMempool.Number
+			p.mpoolInfo.NumTicketPurchasesInMempool = data.Ticketfees.FeeInfoMempool.Number
 
 			// Store mempool data with each saver
+			timestamp := time.Now()
 			for _, s := range p.dataSavers {
 				if s != nil {
 					log.Trace("Saving MP data.")

--- a/ntfnchans.go
+++ b/ntfnchans.go
@@ -6,6 +6,7 @@ package main
 import (
 	"github.com/dcrdata/dcrdata/blockdata"
 	"github.com/dcrdata/dcrdata/dcrsqlite"
+	"github.com/dcrdata/dcrdata/mempool"
 	"github.com/dcrdata/dcrdata/stakedb"
 	"github.com/dcrdata/dcrdata/txhelpers"
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -18,7 +19,7 @@ const (
 
 	// newTxChanBuffer is the size of the new transaction channel buffer, for
 	// ANY transactions are added into mempool.
-	newTxChanBuffer = 4096
+	newTxChanBuffer = 20
 
 	reorgBuffer = 2
 
@@ -41,7 +42,7 @@ var ntfnChans struct {
 	updateStatusDBHeight              chan uint32
 	spendTxBlockChan, recvTxBlockChan chan *txhelpers.BlockWatchedTx
 	relevantTxMempoolChan             chan *dcrutil.Tx
-	newTxChan                         chan *chainhash.Hash
+	newTxChan                         chan *mempool.NewTx
 }
 
 func makeNtfnChans(cfg *config) {
@@ -81,7 +82,7 @@ func makeNtfnChans(cfg *config) {
 	// }
 
 	if cfg.MonitorMempool {
-		ntfnChans.newTxChan = make(chan *chainhash.Hash, newTxChanBuffer)
+		ntfnChans.newTxChan = make(chan *mempool.NewTx, newTxChanBuffer)
 	}
 }
 

--- a/ntfnhandlers.go
+++ b/ntfnhandlers.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dcrdata/dcrdata/blockdata"
+	"github.com/dcrdata/dcrdata/dcrsqlite"
 	"github.com/dcrdata/dcrdata/mempool"
 	"github.com/dcrdata/dcrdata/stakedb"
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -109,7 +109,7 @@ func getNodeNtfnHandlers(cfg *config) *dcrrpcclient.NotificationHandlers {
 			newHash *chainhash.Hash, newHeight int32) {
 			// Send reorg data to dcrsqlite's monitor
 			select {
-			case ntfnChans.reorgChanBlockData <- &blockdata.ReorgData{
+			case ntfnChans.reorgChanWiredDB <- &dcrsqlite.ReorgData{
 				OldChainHead:   *oldHash,
 				OldChainHeight: oldHeight,
 				NewChainHead:   *newHash,

--- a/ntfnhandlers.go
+++ b/ntfnhandlers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/dcrdata/dcrdata/blockdata"
+	"github.com/dcrdata/dcrdata/mempool"
 	"github.com/dcrdata/dcrdata/stakedb"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
@@ -174,8 +175,9 @@ func getNodeNtfnHandlers(cfg *config) *dcrrpcclient.NotificationHandlers {
 		OnTxAccepted: func(hash *chainhash.Hash, amount dcrutil.Amount) {
 			// Just send the tx hash and let the goroutine handle everything.
 			select {
-			case ntfnChans.newTxChan <- hash:
+			case ntfnChans.newTxChan <- &mempool.NewTx{hash, time.Now()}:
 			default:
+				log.Warn("newTxChan buffer full!")
 			}
 			//log.Trace("Transaction accepted to mempool: ", hash, amount)
 		},


### PR DESCRIPTION
Send the new `mempool.NewTx` type, which includes a time stamp, instead of just a `chainhash.Hash`.  If age of NewTx is greater than time since last mempool collection, that tx has already been included in a collection and it should not trigger a new collection.
Clean up `(*mempoolMonitor).TxHandler`

This also sneaks in a fix for the sqlite reorg handler not running.  It will run now, but it's not yet clear if it will work as intended.