### PR TITLE
collectionQueue to run certain collection functions synchronously and in order

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ by other dcrdata packages, but they may be of general value in the future.
 * The `chainMonitor` type and its `BlockConnectedHandler()` method that handles
   block-connected notifications and triggers data collection and storage.
 * The `BlockData` type and methods for converting to API types.
-* The `blockDataCollector` type its `Collect()` method that is called by
-  the chain monitor when a new block is detected.
+* The `blockDataCollector` type and its `Collect()` and `CollectHash()` methods
+  that are called by the chain monitor when a new block is detected.
 * The `BlockDataSaver` interface required by `chainMonitor` for storage of
   collected data.
 

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -131,6 +131,7 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 	var ticketPoolInfo *apitypes.TicketPoolInfo
 	var found bool
 	if ticketPoolInfo, found = t.stakeDB.PoolInfo(*hash); !found {
+		log.Infof("Unable to find block (%s) in pool info cache, trying best block.", hash.String())
 		tpi, sdbHeight := t.stakeDB.PoolInfoBest()
 		if sdbHeight != height {
 			log.Warnf("Collected block height %d != stake db height %d. Pool info "+

--- a/blockdata/chainmonitor.go
+++ b/blockdata/chainmonitor.go
@@ -104,7 +104,7 @@ out:
 
 			if reorg {
 				p.sideChain = append(p.sideChain, *hash)
-				log.Infof("Adding block %v to sidechain", *hash)
+				log.Tracef("Adding block %v to blockdata sidechain", *hash)
 
 				// Just append to side chain until the new main chain tip block is reached
 				if !reorgData.NewChainHead.IsEqual(hash) {
@@ -117,7 +117,7 @@ out:
 				p.reorgLock.Lock()
 				p.reorganizing = false
 				p.reorgLock.Unlock()
-				log.Infof("Reorganization to block %v (height %d) complete",
+				log.Tracef("Reorganization to block %v (height %d) complete in blockdata",
 					p.reorgData.NewChainHead, p.reorgData.NewChainHeight)
 				// dcrsqlite's chainmonitor handles the reorg collection
 				release()
@@ -127,7 +127,7 @@ out:
 			msgBlock, _ := p.collector.dcrdChainSvr.GetBlock(hash)
 			block := dcrutil.NewBlock(msgBlock)
 			height := block.Height()
-			log.Infof("Block height %v connected", height)
+			log.Infof("Block height %v connected. Collecting data...", height)
 
 			if len(p.watchaddrs) > 0 {
 				// txsForOutpoints := blockConsumesOutpointWithAddresses(block, p.watchaddrs,
@@ -194,8 +194,7 @@ out:
 
 }
 
-// ReorgHandler receives notification of a chain reorganization and initiates a
-// corresponding update of the SQL db keeping the main chain data.
+// ReorgHandler receives notification of a chain reorganization
 func (p *chainMonitor) ReorgHandler() {
 	defer p.wg.Done()
 out:
@@ -224,9 +223,9 @@ out:
 			p.reorgData = reorgData
 			p.reorgLock.Unlock()
 
-			log.Infof("Reorganize started. NEW head block %v at height %d.",
+			log.Tracef("Reorganize started in blockdata. NEW head block %v at height %d.",
 				newHash, newHeight)
-			log.Infof("Reorganize started. OLD head block %v at height %d.",
+			log.Tracef("Reorganize started in blockdata. OLD head block %v at height %d.",
 				oldHash, oldHeight)
 
 		case _, ok := <-p.quit:

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -80,8 +80,8 @@ func (db *wiredDB) SyncDB(wg *sync.WaitGroup, quit chan struct{}) error {
 		return err
 	}
 	// Do not allow Store() while doing sync
-	db.mtx.Lock()
-	defer db.mtx.Unlock()
+	db.Lock()
+	defer db.Unlock()
 	return db.resyncDB(quit)
 }
 
@@ -95,8 +95,8 @@ func (db *wiredDB) SyncDBWithPoolValue(wg *sync.WaitGroup, quit chan struct{}) e
 		return err
 	}
 	// Do not allow Store() while doing sync
-	db.mtx.Lock()
-	defer db.mtx.Unlock()
+	db.Lock()
+	defer db.Unlock()
 	return db.resyncDBWithPoolValue(quit)
 }
 

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -79,9 +79,7 @@ func (db *wiredDB) SyncDB(wg *sync.WaitGroup, quit chan struct{}) error {
 	if err = db.client.Ping(); err != nil {
 		return err
 	}
-	// Do not allow Store() while doing sync
-	db.Lock()
-	defer db.Unlock()
+
 	return db.resyncDB(quit)
 }
 
@@ -94,9 +92,7 @@ func (db *wiredDB) SyncDBWithPoolValue(wg *sync.WaitGroup, quit chan struct{}) e
 	if err = db.client.Ping(); err != nil {
 		return err
 	}
-	// Do not allow Store() while doing sync
-	db.Lock()
-	defer db.Unlock()
+
 	return db.resyncDBWithPoolValue(quit)
 }
 

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -49,12 +49,15 @@ func newWiredDB(DB *DB, statusC chan uint32, cl *dcrrpcclient.Client, p *chaincf
 	return wDB, wDB.sDB.StakeDB.Close
 }
 
-// NewWiredDB returns a new database
+// NewWiredDB creates a new wiredDB from a *sql.DB, a node client, network
+// parameters, and a status update channel. It calls dcrsqlite.NewDB to create a
+// new DB that wrapps the sql.DB.
 func NewWiredDB(db *sql.DB, statusC chan uint32, cl *dcrrpcclient.Client, p *chaincfg.Params) (wiredDB, func() error) {
 	return newWiredDB(NewDB(db), statusC, cl, p)
 }
 
-// InitWiredDB initializes the wiredDB
+// InitWiredDB creates a new wiredDB from a file containing the data for a
+// sql.DB. The other parameters are same as those for NewWiredDB.
 func InitWiredDB(dbInfo *DBInfo, statusC chan uint32, cl *dcrrpcclient.Client, p *chaincfg.Params) (wiredDB, func() error, error) {
 	db, err := InitDB(dbInfo)
 	if err != nil {

--- a/dcrsqlite/sync.go
+++ b/dcrsqlite/sync.go
@@ -257,6 +257,7 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 		var tpi *apitypes.TicketPoolInfo
 		var found bool
 		if tpi, found = db.sDB.PoolInfo(*blockhash); !found {
+			log.Infof("Unable to find block (%s) in pool info cache, trying best block.", blockhash.String())
 			ticketPoolInfo, sdbHeight := db.sDB.PoolInfoBest()
 			if int64(sdbHeight) != i {
 				log.Warnf("Collected block height %d != stake db height %d. Pool info "+

--- a/dcrsqlite/sync.go
+++ b/dcrsqlite/sync.go
@@ -254,7 +254,16 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 				i, endRangeBlock, numLive)
 		}
 
-		tpi, _ := db.sDB.PoolInfo()
+		var tpi *apitypes.TicketPoolInfo
+		var found bool
+		if tpi, found = db.sDB.PoolInfo(*blockhash); !found {
+			ticketPoolInfo, sdbHeight := db.sDB.PoolInfoBest()
+			if int64(sdbHeight) != i {
+				log.Warnf("Collected block height %d != stake db height %d. Pool info "+
+					"will not match the rest of this block's data.", height, i)
+			}
+			tpi = &ticketPoolInfo
+		}
 
 		header := block.MsgBlock().Header
 		diffRatio := txhelpers.GetDifficultyRatio(header.Bits, db.params)
@@ -266,7 +275,7 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 			Difficulty: diffRatio,
 			StakeDiff:  dcrutil.Amount(header.SBits).ToCoin(),
 			Time:       header.Timestamp.Unix(),
-			PoolInfo:   tpi,
+			PoolInfo:   *tpi,
 		}
 
 		// TODO: Why was there a discrepancy using a ticket cache in this function?

--- a/dcrsqlite/sync.go
+++ b/dcrsqlite/sync.go
@@ -139,7 +139,7 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 	// Time this function
 	defer func(start time.Time, perr *error) {
 		if *perr != nil {
-			log.Infof("Collector.Collect() completed in %v", time.Since(start))
+			log.Infof("resyncDBWithPoolValue() completed in %v", time.Since(start))
 		}
 	}(time.Now(), &err)
 

--- a/dcrsqlite/sync.go
+++ b/dcrsqlite/sync.go
@@ -257,10 +257,10 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 		var tpi *apitypes.TicketPoolInfo
 		var found bool
 		if tpi, found = db.sDB.PoolInfo(*blockhash); !found {
-			log.Infof("Unable to find block (%s) in pool info cache, trying best block.", blockhash.String())
+			log.Warnf("Unable to find block (%s) in pool info cache. Resync is malfunctioning!", blockhash.String())
 			ticketPoolInfo, sdbHeight := db.sDB.PoolInfoBest()
 			if int64(sdbHeight) != i {
-				log.Warnf("Collected block height %d != stake db height %d. Pool info "+
+				log.Errorf("Collected block height %d != stake db height %d. Pool info "+
 					"will not match the rest of this block's data.", height, i)
 			}
 			tpi = &ticketPoolInfo
@@ -278,12 +278,6 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 			Time:       header.Timestamp.Unix(),
 			PoolInfo:   *tpi,
 		}
-
-		// TODO: Why was there a discrepancy using a ticket cache in this function?
-		// if blockSummary.PoolInfo != tpi {
-		// 	fmt.Println(blockSummary.PoolInfo)
-		// 	fmt.Println(tpi)
-		// }
 
 		if i > bestBlockHeight {
 			if err = db.StoreBlockSummary(&blockSummary); err != nil {

--- a/log.go
+++ b/log.go
@@ -47,20 +47,20 @@ var (
 	// application shutdown.
 	logRotator *rotator.Rotator
 
-	sqliteLog  = backendLog.Logger("DSQL")
-	stakedbLog = backendLog.Logger("SKDB")
-	daemonLog  = backendLog.Logger("DCRD")
-	clientLog  = backendLog.Logger("RPCC")
-	mempoolLog = backendLog.Logger("MEMP")
-	apiLog     = backendLog.Logger("JAPI")
-	log        = backendLog.Logger("DATD")
+	sqliteLog    = backendLog.Logger("DSQL")
+	stakedbLog   = backendLog.Logger("SKDB")
+	blockdataLog = backendLog.Logger("BLKD")
+	clientLog    = backendLog.Logger("RPCC")
+	mempoolLog   = backendLog.Logger("MEMP")
+	apiLog       = backendLog.Logger("JAPI")
+	log          = backendLog.Logger("DATD")
 )
 
 // Initialize package-global logger variables.
 func init() {
 	dcrsqlite.UseLogger(sqliteLog)
 	stakedb.UseLogger(stakedbLog)
-	blockdata.UseLogger(daemonLog)
+	blockdata.UseLogger(blockdataLog)
 	dcrrpcclient.UseLogger(clientLog)
 	rpcutils.UseLogger(clientLog)
 	mempool.UseLogger(mempoolLog)
@@ -70,7 +70,7 @@ func init() {
 var subsystemLoggers = map[string]btclog.Logger{
 	"DSQL": sqliteLog,
 	"SKDB": stakedbLog,
-	"DCRD": daemonLog,
+	"BLKD": blockdataLog,
 	"RPCC": clientLog,
 	"MEMP": mempoolLog,
 	"JAPI": apiLog,

--- a/ntfnhandlers.go
+++ b/ntfnhandlers.go
@@ -71,6 +71,8 @@ type collectionQueue struct {
 	syncHandlers []func(hash *chainhash.Hash)
 }
 
+// NewCollectionQueue creates a new collectionQueue with a queue channel large
+// enough for 10 million block pointers.
 func NewCollectionQueue() *collectionQueue {
 	return &collectionQueue{
 		q: make(chan *blockHashHeight, 1e7),

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -22,17 +22,24 @@ import (
 	"github.com/decred/dcrutil"
 )
 
+// PoolInfoCache contains a map of block hashes to ticket pool info data at that
+// block height.
 type PoolInfoCache struct {
 	sync.RWMutex
 	poolInfo map[chainhash.Hash]*apitypes.TicketPoolInfo
 }
 
+// NewPoolInfoCache constructs a new PoolInfoCache, and is needed to initialize
+// the internal map.
 func NewPoolInfoCache() *PoolInfoCache {
 	return &PoolInfoCache{
 		poolInfo: make(map[chainhash.Hash]*apitypes.TicketPoolInfo),
 	}
 }
 
+// Get attempts to fetch the ticket pool info for a given block hash, returning
+// a *apitypes.TicketPoolInfo, and a bool indicating if the hash was found in
+// the map.
 func (c *PoolInfoCache) Get(hash chainhash.Hash) (*apitypes.TicketPoolInfo, bool) {
 	c.RLock()
 	defer c.RUnlock()
@@ -40,6 +47,7 @@ func (c *PoolInfoCache) Get(hash chainhash.Hash) (*apitypes.TicketPoolInfo, bool
 	return tpi, ok
 }
 
+// Set stores the ticket pool info for the given hash in the pool info cache.
 func (c *PoolInfoCache) Set(hash chainhash.Hash, p *apitypes.TicketPoolInfo) {
 	c.Lock()
 	defer c.Unlock()

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -267,6 +267,8 @@ func (db *StakeDatabase) connectBlock(block *dcrutil.Block, spent []chainhash.Ha
 
 	db.nodeMtx.Unlock()
 
+	// Get ticket pool info at current best (just connected in stakedb) block,
+	// and store it in the StakeDatabase's PoolInfoCache.
 	tpi, _ := db.PoolInfoBest()
 	db.poolInfo.Set(*block.Hash(), &tpi)
 


### PR DESCRIPTION
This still allows the `OnBlockConnected` handler to return quickly and not block the RPC client, but it band-aids some issues with execution order.

Create the `collectionQueue` in `make`/`getNodeNtfnHandlers` and return it to main so that the synchronous collection functions can be set once they are available.

No longer send directly to the block connected channels for  stakedb, wiredDB, or blockdata.  Instead call the new synchronous function `BlockConnectedSync` of each package's chain monitor.  The individual block connected channels are still used in `BlockConnectedSync`, but signals are used to wait until handling of the signaled block has completed in the old handler loops.

Create `blockdata.(*Collector).CollectHash(*chainhash.Hash)` to be used in the event that the chain node best block is higher than the block requested for data collection.  Pool value may be wrong if the stake DB is not on the same height however.  But the new synchronous execution changes are intended to prevent the stake DB from getting ahead.  **EDIT**: This now adds `PoolInfoCache` in stakedb so that ticket pool info for recent (since program start) previous blocks are available.

Update `blockdata.(*chainMonitor).BlockConnectedHandler` so that it will call `Collect()` only if chain height equals the height of the requested block data, and call `CollectHash(hash)` if collection is behind.  A caveat with `CollectHash`, in addition to the pool value bit described above, is that it will not get the next block window estimates, however this is not needed if a higher block is waiting to be processed subsequently.

<s>Change reorg handling in dcrsqlite so that instead of making a slice of block hashes for the new main chain and then trying to collect data for each, which is bad because the stake DB will be at tip and pool value for intermediate blocks will not be available, instead collect with `CollectAPITypes()` and make a slice of  the the data.  The new `blockAPISourceData` type holds this data.  Then in `switchToSideChain()`, just unpack the data.</s>  Reorg handling in dcrsqlite still just stores the block hashes of the side chain, deferring actual data collection until `switchToSidechain`, but the `PoolInfoCache` in stakedb will have pool info for the entire side chain since it's block-connected handler runs _before_ dcrsqlite's.  So as dcrsqlite's chainmonitor runs `CollectAPITypes(hash)` for each side chain block, the correct pool info will be obtained from stakedb.