### PR TITLE
Add sample nginx.conf and rate_limiting.html

### DIFF
--- a/apiroutes.go
+++ b/apiroutes.go
@@ -690,6 +690,8 @@ func (c *appContext) getBlockRangeSummary(w http.ResponseWriter, r *http.Request
 		// TODO: deal with the extra newline from Encode, if needed
 		if err := encoder.Encode(c.BlockData.GetSummary(i)); err != nil {
 			apiLog.Infof("JSON encode error: %v", err)
+			http.Error(w, http.StatusText(422), 422)
+			return
 		}
 		if i != idx {
 			fmt.Fprintf(w, ",%s%s", newline, prefix)

--- a/sample-nginx.conf
+++ b/sample-nginx.conf
@@ -1,0 +1,96 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+    worker_connections 768;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent (comp. $gzip_ratio) "Ref: $http_referer" '
+                      '"$http_user_agent" "XFF: $http_x_forwarded_for" "RealIP: $realip_remote_addr"';
+
+    access_log  /var/log/nginx/access.log  main;
+    error_log /var/log/nginx/error.log;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Ensure ngx_http_realip_module is available
+    set_real_ip_from 127.0.0.1/32;
+    # If you are behind a NAT router, specify LAN
+    #set_real_ip_from 10.24.0/16;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
+    gzip on;
+    gzip_disable "msie6";
+    # configure the rest in the server sections
+
+    server {
+        listen          80 default_server;
+        server_name     _;
+
+        rewrite ^       https://$host$request_uri permanent;
+    }
+
+    # per-IP rate limiting (3 requests / second on average)
+    limit_req_zone $binary_remote_addr zone=dcrdata:10m rate=3r/s;
+    limit_req_log_level error;
+    limit_req_status 429;
+
+    server {
+        listen       443 default_server;
+        server_name  _;
+
+        gzip on;
+        gzip_proxied any;
+        gzip_comp_level 3;
+        gzip_min_length 1024;
+        gzip_types text/css text/* text/javascript application/x-javascript application/json
+                application/xml application/atom+xml application/xaml+xml;
+
+        ssl                     on;
+        ssl_certificate         /etc/letsencrypt/live/dcrdata.org/fullchain.pem;
+        ssl_certificate_key     /etc/letsencrypt/live/dcrdata.org/privkey.pem;
+ 
+        ssl_session_cache               shared:SSL:20m;
+        ssl_protocols                   TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers                     EECDH+CHACHA20:EECDH+CHACHA20-draft:EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+        ssl_prefer_server_ciphers       on;
+        add_header                      Strict-Transport-Security max-age=15552001;
+
+        location / {
+            # apply rate limiting
+            limit_req zone=dcrdata burst=16;
+
+            # proxy with WebSocket upgrade support
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $realip_remote_addr;
+            proxy_pass http://127.0.0.1:7777;
+            proxy_http_version 1.1;
+        }
+
+        # set this up or just remove it
+        error_page 501 502 503 504 /500.html;
+        location = /500.html {
+            root /var/www/html/fallback;
+        }
+
+        error_page 429 /rate_limiting.html;
+        location = /rate_limiting.html {
+            add_header Retry-After 30;
+            root /var/www/html/fallback;
+        }
+    }
+}

--- a/sample-rate_limiting.html
+++ b/sample-rate_limiting.html
@@ -1,0 +1,14 @@
+<!-- Response header should look something like:
+HTTP/1.1 429 Too Many Requests
+Content-Type: text/html
+Retry-After: 30
+-->
+<html>
+<head>
+    <title>Rate Limiting in Effect</title>
+</head>
+<body>
+    <h1>Too Many Requests</h1>
+    <p>I only allow 3 requests per second per client IP, with small bursts permitted. Try again soon.</p>
+</body>
+</html>


### PR DESCRIPTION
The sample nginx.conf demonstrates several important settings when using nginx as a reverse proxy:

- websocket upgrade
- RealIP module
- rate limiting
- auto-HTTPS redirect
- SSL cert setup
- gzip settings

The sample rate_limiting.html demonstrates a possible response to the client when requests are being refused due to rate limiting.