### PR TITLE
Address error handling

### DIFF
--- a/apiroutes.go
+++ b/apiroutes.go
@@ -907,6 +907,10 @@ func (c *appContext) getAddressTransactions(w http.ResponseWriter, r *http.Reque
 		count = 10
 	}
 	txs := c.BlockData.GetAddressTransactions(address, count)
+	if txs == nil {
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
 	writeJSON(w, txs, c.getIndentQuery(r))
 }
 
@@ -921,5 +925,9 @@ func (c *appContext) getAddressTransactionsRaw(w http.ResponseWriter, r *http.Re
 		count = 10
 	}
 	txs := c.BlockData.GetAddressTransactionsRaw(address, count)
+	if txs == nil {
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
 	writeJSON(w, txs, c.getIndentQuery(r))
 }

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -474,12 +474,12 @@ func (db *wiredDB) GetMempoolSSTxDetails(N int) *apitypes.MempoolTicketDetails {
 func (db *wiredDB) GetAddressTransactions(addr string, count int) *apitypes.Address {
 	address, err := dcrutil.DecodeAddress(addr)
 	if err != nil {
-		log.Errorf("Invalid address %s: %v", addr, err)
+		log.Infof("Invalid address %s: %v", addr, err)
 		return nil
 	}
 	txs, err := db.client.SearchRawTransactionsVerbose(address, 0, count, false, false, nil)
 	if err != nil {
-		log.Errorf("GetAddressTransactions failed for address %s: %v", addr, err)
+		log.Warnf("GetAddressTransactions failed for address %s: %v", addr, err)
 		return nil
 	}
 	tx := make([]*apitypes.AddressTxShort, 0, len(txs))
@@ -508,12 +508,12 @@ func (db *wiredDB) GetAddressTransactions(addr string, count int) *apitypes.Addr
 func (db *wiredDB) GetAddressTransactionsRaw(addr string, count int) []*apitypes.AddressTxRaw {
 	address, err := dcrutil.DecodeAddress(addr)
 	if err != nil {
-		log.Errorf("Invalid address %s: %v", addr, err)
+		log.Infof("Invalid address %s: %v", addr, err)
 		return nil
 	}
 	txs, err := db.client.SearchRawTransactionsVerbose(address, 0, count, true, false, nil)
 	if err != nil {
-		log.Errorf("GetAddressTransactionsRaw failed for address %s: %v", addr, err)
+		log.Warnf("GetAddressTransactionsRaw failed for address %s: %v", addr, err)
 		return nil
 	}
 	txarray := make([]*apitypes.AddressTxRaw, 0, len(txs))


### PR DESCRIPTION
For bad input address:

- return 422 Unprocessable Entity, not null
- log at level Info. For failed searchrawtransactions, warn