### PR TITLE
Added querying for blocks from time frame

### DIFF
--- a/apimiddleware.go
+++ b/apimiddleware.go
@@ -27,6 +27,7 @@ const (
 	ctxTxHash
 	ctxTxInOutIndex
 	ctxN
+	ctxDate
 )
 
 func (c *appContext) StatusCtx(next http.Handler) http.Handler {
@@ -201,6 +202,16 @@ func AddressPathCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		address := chi.URLParam(r, "address")
 		ctx := context.WithValue(r.Context(), ctxAddress, address)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// DatePathCtx returns a http.HandlerFunc that embeds the value at the url part
+// {date} into the request context
+func DatePathCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		date := chi.URLParam(r, "date")
+		ctx := context.WithValue(r.Context(), ctxDate, date)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/apirouter.go
+++ b/apirouter.go
@@ -91,6 +91,12 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 			// rd.Get("/pos", app.getBlockStakeInfoExtended)
 		})
 
+		r.Route("/time", func(rd chi.Router) {
+
+			rd.Use(middleware.Compress(1))
+			rd.Get("/day", app.getBlockSummaryByDate)
+			rd.With(DatePathCtx).Get("/day/{date}", app.getBlockSummaryByDate)
+		})
 		//r.With(middleware.DefaultCompress).Get("/raw", app.someLargeResponse)
 	})
 

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -387,6 +387,15 @@ func (db *wiredDB) GetBlockSizeRange(idx0, idx1 int) ([]int32, error) {
 	return blockSizes, nil
 }
 
+func (db *wiredDB) GetBlockSummaryByTime(start, end int) ([]*apitypes.BlockDataBasic, error) {
+	blocks, err := db.RetrieveBlockSummaryRangeTime(int64(start), int64(end))
+	if err != nil {
+		log.Errorf("Unable to retrieve block summaries from time range: %v", err)
+		return nil, err
+	}
+	return blocks, nil
+}
+
 func (db *wiredDB) GetPoolInfo(idx int) *apitypes.TicketPoolInfo {
 	ticketPoolInfo, err := db.RetrievePoolInfo(int64(idx))
 	if err != nil {


### PR DESCRIPTION
for issue #106, added a way to get blocks from a timeframe and added an example endpoint `/api/block/time/day/{MM-DD-YYY}` to get blocks on an specific day,  `/api/block/time/day/` returns blocks from the current day. Wanted a review before proceeding