### PR TITLE
dock footer nav to bottom of page

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -9,19 +9,28 @@
 /* Quick and Dirty CSS, just layer on top of boostrap */
 
 html {
-    color: #5f5f5f;
+  color: #5f5f5f;
+  min-height: 100vh;
+}
+body {
+  position: relative;
+  min-height: 100vh;
+  padding-bottom: 42px;
 }
 .hidden {
   visibility: hidden;
 }
-
 .top-nav,
 .navbar-fixed-bottom {
     background: #3B3F45;
 }
 .navbar-fixed-bottom {
-  color: silver;
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 22px;
   font-size: 12px;
+  color: silver;
   line-height: 22px;
 }
 .top-nav a {


### PR DESCRIPTION
This change makes sure the page body expands the full height of the page and the footer nav is absolutely position to the bottom. 

This means the footer won't be visible in mobile unless you scroll all the way down, but the upside is it maximizes the amount of vertical screen real estate for viewing data.

Sample mobile view:
<img width="399" alt="screen shot 2017-09-05 at 6 52 44 pm" src="https://user-images.githubusercontent.com/25571523/30090957-9e386640-926b-11e7-8216-b561c7f65e19.png">
 
But we can also do fixed position, which means it will always be visible, eg:
<img width="398" alt="screen shot 2017-09-05 at 6 53 03 pm" src="https://user-images.githubusercontent.com/25571523/30090967-ac01b754-926b-11e7-9cd5-5f1d4b453069.png">

Let me know which approach you prefer to address
https://github.com/dcrdata/dcrdata/issues/109
