### PR TITLE
move github/api/status links into footer, render #connection conditionally

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -9,10 +9,13 @@
 /* Quick and Dirty CSS, just layer on top of boostrap */
 
 html {
-    color: #5f5f5f;
+  color: #5f5f5f;
+}
+body {
+  padding-bottom: 2.1rem;
 }
 .hidden {
-  visibility: hidden;
+  display: none;
 }
 
 .top-nav,
@@ -27,12 +30,26 @@ html {
   font-size: 12px;
   line-height: 22px;
 }
+
 .top-nav a {
     color: white;
 }
 .top-search {
   height: 30px;
   margin: 2px 0 !important;
+}
+
+.navbar-fixed-bottom {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  font-size: 12px;
+  line-height: 22px;
+}
+.navbar-fixed-bottom .nav-item {
+  color: silver;
+  padding: 0 6px;
+  position: relative;
 }
 h4 {
     margin-top: 10px;
@@ -63,13 +80,12 @@ h4 {
 }
 @media only screen and (max-width: 940px)  {
     .hash.collapse {
-        font-size: 10px;
         width: 142px;
     }
 }
 @media only screen and (max-width: 768px)  {
     .hash.collapse {
-        font-size: 12px;
+        width: 198px;
     }
     .table {
         margin-bottom: 0;
@@ -85,3 +101,4 @@ h4 {
         width: 198px;
     }
 }
+

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -37,6 +37,9 @@
             </div>
         </div>
     </div>
+
+    {{template "footer"}}
+
 </body>
 </html>
 {{end}}

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -174,7 +174,8 @@
     </div>
 </div>
 
-</body>
+{{template "footer"}}
 
+</body>
 </html>
 {{ end }}

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -127,8 +127,10 @@
         if (parseInt(best.innerText) == first) {
             next.className = "hidden"
         }
-        </script>
-</body>
+    </script>
 
+{{template "footer"}}
+
+</body>
 </html>
 {{ end }}

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -35,12 +35,11 @@
 {{define "navbar"}}
 <div class="top-nav">
     <div class="container">
-        <div class="d-flex align-items-center">
-            <div class="col-sm-auto"><a href="/">Home</a></div>
-            <div class="col-sm-auto"><a href="https://github.com/dcrdata/dcrdata" title="dcrdata on GitHub" target="_blank">GitHub</a></div>
-            <div class="col-sm-auto"><a href="https://github.com/dcrdata/dcrdata#json-rest-api" title="API Endpoints" target="_blank">API</a></div>
-            <div class="col-sm-auto"><a href="/api/status" title="API Status" target="_blank">Status</a></div>
-            <div class="col-sm-auto"><a href="/explorer" title="Explorer">Explore</a></div>
+        <div class="d-flex align-items-center flex-wrap">
+            <div class="d-flex align-items-center">
+                <div class="col-sm-auto"><a href="/">Home</a></div>
+                <div class="col-sm-auto"><a href="/explorer" title="Explorer">Explore</a></div>
+            </div>
             <div class="col">
                 <form class="navbar-form" role="search" id="search-form">
                     <div class="input-group">
@@ -67,4 +66,17 @@
             }
           }
 </script>
+{{end}}
+
+
+{{define "footer"}}
+<footer class="navbar-fixed-bottom">
+    <div class="container wrapper text-center">
+        <a class="nav-item" href="dcrdata.org">dcrdata.org</a>
+        <a class="nav-item" href="https://github.com/dcrdata/dcrdata" title="dcrdata on GitHub" target="_blank">GitHub</a>
+        <a class="nav-item" href="https://github.com/dcrdata/dcrdata#json-rest-api" title="API Endpoints" target="_blank">API</a>
+        <a class="nav-item" href="/api/status" title="API Status" target="_blank">Status</a>
+        <span class="nav-item hidden" id="connection">Connecting to WebSocket...<div></div></span>
+    </div>
+</footer>
 {{end}}

--- a/views/root.tmpl
+++ b/views/root.tmpl
@@ -37,6 +37,7 @@
                         }
                     }
                     #connection {
+                        top: -1px;
                         font: 12px sans-serif;
                         font-weight: bold;
                         vertical-align: middle;
@@ -54,7 +55,7 @@
                         -webkit-animation-timing-function: linear;
                     }
                     #connection.connected div {
-                        background-color: green;
+                        background-color: #63df1e;
                         -webkit-box-shadow: rgba(0, 255, 0, 0.5) 0px 0px 5px;
                         -webkit-animation-name: glowGreen;
                     }
@@ -210,7 +211,12 @@
         }, 1000);
 
 	    function updateConnectionStatus(msg, connected) {
-            var el = document.querySelector('#connection');
+            var el = document.getElementById('connection');
+            if (el.classList) {
+                el.classList.remove('hidden');
+            } else {
+                el.removeClass('hidden');
+            }
             if (connected) {
                 if (el.classList) {
                     el.classList.add('connected');
@@ -374,13 +380,7 @@
     </div>
     <!-- end wrapper -->
 
-    <footer class="navbar-fixed-bottom">
-      <div class="container wrapper text-center">
-        <strong>dcrdata</strong>.org &emsp; | &emsp;  <span id="connection">Connecting to WebSocket...<div></div></span>
-      </div>
-    </footer>
-
-    <!-- <script src="js/complete.js"></script> -->
+    {{ template "footer"}}
 
 </body>
 

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -5,7 +5,6 @@
 <body>
 {{template "navbar"}}
 
-
 <div class="container">
     <div class="row">
         <div class="col-md-12">
@@ -89,6 +88,9 @@
             </table>
         </div>
     </div>
+</div>
+
+{{template "footer"}}
 
 </body>
 </html>


### PR DESCRIPTION
- Makes footer present on all pages.
- Moves the top nav links that lead off the site into the footer nav.
- Hides WebSocket activity indicator render unless connection script is running.

This reorg frees up space to make more room for search on small screens https://github.com/dcrdata/dcrdata/issues/115