### PR TITLE
Previous OutPoint Addresses in Tx view

### DIFF
--- a/apiroutes.go
+++ b/apiroutes.go
@@ -25,6 +25,7 @@ type APIDataSource interface {
 	GetBlockVerboseByHash(hash string, verboseTx bool) *dcrjson.GetBlockVerboseResult
 	GetBlockVerboseWithStakeTxDetails(hash string) *apitypes.BlockDataWithTxType
 	GetRawTransaction(txid string) *apitypes.Tx
+	GetRawTransactionWithPrevOutAddresses(txid string) (*apitypes.Tx, [][]string)
 	GetAllTxIn(txid string) []*apitypes.TxIn
 	GetAllTxOut(txid string) []*apitypes.TxOut
 	GetTransactionsForBlock(idx int64) *apitypes.BlockTransactions

--- a/explorer.go
+++ b/explorer.go
@@ -107,13 +107,19 @@ func (exp *explorerUI) txPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/error/"+hash, http.StatusTemporaryRedirect)
 		return
 	}
-	data := exp.app.BlockData.GetRawTransaction(hash)
-	if data == nil {
+	tx, prevOutAddresses := exp.app.BlockData.GetRawTransactionWithPrevOutAddresses(hash)
+	if tx == nil {
 		apiLog.Errorf("Unable to get transaction %s", hash)
 		http.Redirect(w, r, "/error/"+hash, http.StatusTemporaryRedirect)
 		return
 	}
-	str, err := TemplateExecToString(exp.templates[txTemplateIndex], "tx", data)
+	txSuppl := struct {
+		*apitypes.Tx
+		VinAddrs [][]string
+	}{
+		tx, prevOutAddresses,
+	}
+	str, err := TemplateExecToString(exp.templates[txTemplateIndex], "tx", txSuppl)
 	if err != nil {
 		apiLog.Errorf("Template execute failure: %v", err)
 		http.Redirect(w, r, "/error/"+hash, http.StatusTemporaryRedirect)

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -177,6 +177,18 @@ h4 {
   width: 198px;
 }
 
+.outpoint {
+  font-family: monospace;
+  display: inline-block;
+  word-wrap: break-word;
+  transition: .133s transform;
+}
+.outpoint.collapse {
+  font-size: 10px;
+  display: inline-block;
+  width: 206px;
+}
+
 /*responsive*/
 @media only screen and (max-width: 992px)  {
   .container {

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -60,34 +60,42 @@
             <h4>In</h4>
             <table class="table table-sm striped">
                 <thead>
-                    <th>Transaction</th>
-                    <th class="nowrap">Block Height </th>
-                    <th>Sequence</th>
-                    <th>Tree</th>
+                    <th>Previous Outpoint</th>
+                    <th>Addresses</th>
+                    <!-- <th>Tree</th> -->
+                    <th class="nowrap">Block</th>
                     <th>Value</th>
                 </thead>
                 <tbody>
-                    {{range .Vin}}
+                    {{range $i, $vin := .Vin}}
                     <tr>
                         <td>
-                            {{if .Coinbase}}
-                                Coinbase: {{ .Coinbase }}
-                            {{else if eq .Txid "0000000000000000000000000000000000000000000000000000000000000000"}}
+                            {{if $vin.Coinbase}}
+                                Coinbase: {{ $vin.Coinbase }}
+                            {{else if eq $vin.Txid "0000000000000000000000000000000000000000000000000000000000000000"}}
                                 Vote Reward
                             {{else}}
-                            <a href="/explorer/tx/{{.Txid}}"><span class="hash collapse">{{.Txid}}</span></a>
+                            <a href="/explorer/tx/{{$vin.Txid}}"><span class="outpoint collapse">{{$vin.Txid}}:{{$vin.Vout}}</span></a>
                             {{end}}
                         </td>
+                        <td><div class="hash">
+                        {{with $as := index $.VinAddrs $i}}
+                            {{if (len $as) gt 0}}
+                                {{index $as 0}}
+                            {{else}}
+                                N/A
+                            {{end}}
+                        {{end}}
+                        </div></td>
+                        <!-- <td>{{$vin.Tree}}</td> -->
                         <td>
-                        {{if eq .BlockHeight 0}}
+                        {{if eq $vin.BlockHeight 0}}
                             N/A
                         {{else}}
-                            <a href="/explorer/block/{{$.Block.BlockHash}}">{{.BlockHeight}}</a></td>
+                            <a href="/explorer/block/{{$.Block.BlockHash}}">{{$vin.BlockHeight}}</a></td>
                         {{end}}
                         </td>
-                        <td>{{.Sequence}}</td>
-                        <td>{{.Tree}}</td>
-                        <td>{{if lt .AmountIn 0.0}} N/A {{else}} {{getAmount .AmountIn}} {{end}}</td>
+                        <td>{{if lt $vin.AmountIn 0.0}} N/A {{else}} {{getAmount $vin.AmountIn}} {{end}}</td>
                     </tr>
                     {{end}}
                 </tbody>


### PR DESCRIPTION
Modify the tx.tmpl for the Transaction page so that it shows the Previous Outpoints, their first Address (could be multisig), Block, and Value. Tree is dropped.
Add txhelpers.OutPointAddresses, which gets the addresses payed to by a transaction output.
The outpoint CSS class is added to be a bit wider than the hash type.

This probably needs tweaking, but here it is:
![image](https://user-images.githubusercontent.com/9373513/30245122-85f33e8e-9595-11e7-8f5c-c573e186330e.png)
