### PR TITLE
Add SSGen/vote inspection helpers

### DIFF
--- a/apirouter.go
+++ b/apirouter.go
@@ -121,6 +121,7 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 				ri.Get("/", app.getTransactionInputs)
 				ri.With(TransactionIOIndexCtx).Get("/{txinoutindex}", app.getTransactionInput)
 			})
+			rd.Get("/vinfo", app.getTxVoteInfo)
 		})
 	})
 

--- a/apiroutes.go
+++ b/apiroutes.go
@@ -441,7 +441,7 @@ func (c *appContext) getTxVoteInfo(w http.ResponseWriter, r *http.Request) {
 	vinfo, err := c.BlockData.GetVoteInfo(txid)
 	if err != nil {
 		apiLog.Errorf("Unable to get vote info for transaction %s", txid)
-		http.Error(w, "Unable to get vote info, is tx "+txid+" a vote?", 422)
+		http.Error(w, "Unable to get vote info. Is tx "+txid+" a vote?", 422)
 		return
 	}
 	writeJSON(w, vinfo, c.getIndentQuery(r))

--- a/apiroutes.go
+++ b/apiroutes.go
@@ -26,6 +26,7 @@ type APIDataSource interface {
 	GetBlockVerboseWithStakeTxDetails(hash string) *apitypes.BlockDataWithTxType
 	GetRawTransaction(txid string) *apitypes.Tx
 	GetRawTransactionWithPrevOutAddresses(txid string) (*apitypes.Tx, [][]string)
+	GetVoteInfo(txid string) (*apitypes.VoteInfo, error)
 	GetAllTxIn(txid string) []*apitypes.TxIn
 	GetAllTxOut(txid string) []*apitypes.TxOut
 	GetTransactionsForBlock(idx int64) *apitypes.BlockTransactions
@@ -429,6 +430,21 @@ func (c *appContext) getTransaction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, tx, c.getIndentQuery(r))
+}
+
+func (c *appContext) getTxVoteInfo(w http.ResponseWriter, r *http.Request) {
+	txid := getTxIDCtx(r)
+	if txid == "" {
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+	vinfo, err := c.BlockData.GetVoteInfo(txid)
+	if err != nil {
+		apiLog.Errorf("Unable to get vote info for transaction %s", txid)
+		http.Error(w, "Unable to get vote info, is tx "+txid+" a vote?", 422)
+		return
+	}
+	writeJSON(w, vinfo, c.getIndentQuery(r))
 }
 
 // getTransactionInputs serves []TxIn

--- a/dcrdataapi/apitypes.go
+++ b/dcrdataapi/apitypes.go
@@ -43,17 +43,18 @@ type TxShort struct {
 	Vout     []Vout        `json:"vout"`
 }
 
-// VoteInfo models data about a SSGEN Transaction (Vote)
+// VoteInfo models data about a SSGen transaction (vote)
 type VoteInfo struct {
 	Validation BlockValidation         `json:"block_validation"`
 	Version    uint32                  `json:"vote_version"`
 	Choices    []*txhelpers.VoteChoice `json:"vote_choices"`
 }
 
-//BlockValidation models data about a votes decision on a block
+// BlockValidation models data about a vote's decision on a block
 type BlockValidation struct {
-	Height   int64 `json:"height"`
-	Validity bool  `json:"block_validity"`
+	Hash     string `json:"hash"`
+	Height   int64  `json:"height"`
+	Validity bool   `json:"validity"`
 }
 
 // BlockID models very basic info about a block

--- a/dcrdataapi/apitypes.go
+++ b/dcrdataapi/apitypes.go
@@ -4,6 +4,7 @@
 package dcrdataapi
 
 import (
+	"github.com/dcrdata/dcrdata/txhelpers"
 	"github.com/decred/dcrd/dcrjson"
 )
 
@@ -40,6 +41,19 @@ type TxShort struct {
 	Expiry   uint32        `json:"expiry"`
 	Vin      []dcrjson.Vin `json:"vin"`
 	Vout     []Vout        `json:"vout"`
+}
+
+// VoteInfo models data about a SSGEN Transaction (Vote)
+type VoteInfo struct {
+	Validation BlockValidation         `json:"block_validation"`
+	Version    uint32                  `json:"vote_version"`
+	Choices    []*txhelpers.VoteChoice `json:"vote_choices"`
+}
+
+//BlockValidation models data about a votes decision on a block
+type BlockValidation struct {
+	Height   int64 `json:"height"`
+	Validity bool  `json:"block_validity"`
 }
 
 // BlockID models very basic info about a block

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -376,23 +376,24 @@ type BlockValidation struct {
 // chaincfg.Params.Deployments[VoteVersion][VoteIndex].
 type VoteChoice struct {
 	// Single unique word identifying the vote.
-	ID string
+	ID string `json:"id"`
 
 	// Longer description of what the vote is about.
-	Description string
+	Description string `json:"description"`
 
 	// Usable bits for this vote.
-	Mask uint16
+	Mask uint16 `json:"mask"`
 
 	// VoteVersion and VoteIndex specify which vote item is referenced by this
 	// VoteChoice (i.e. chaincfg.Params.Deployments[VoteVersion][VoteIndex]).
-	VoteVersion uint32
-	VoteIndex   int
+	VoteVersion uint32 `json:"vote_version"`
+	VoteIndex   int    `json:"vote_index"`
+
+	// ChoiceIdx indicates the corresponding element in the vote item's []Choice
+	ChoiceIdx int `json:"choice_index"`
 
 	// Choice is the selected choice for the specified vote item
-	Choice *chaincfg.Choice
-	// ChoiceIdx indicates the corresponding element in the vote item's []Choice
-	ChoiceIdx int
+	Choice *chaincfg.Choice `json:"choice"`
 }
 
 // SSGenVoteChoices gets a ssgen's vote choices (block validity and any
@@ -425,8 +426,8 @@ func SSGenVoteChoices(tx *wire.MsgTx, params *chaincfg.Params) (BlockValidation,
 			Mask:        voteAgenda.Mask,
 			VoteVersion: voteVersion,
 			VoteIndex:   d,
-			Choice:      &voteAgenda.Choices[choiceIndex],
 			ChoiceIdx:   choiceIndex,
+			Choice:      &voteAgenda.Choices[choiceIndex],
 		}
 		choices = append(choices, &voteChoice)
 	}


### PR DESCRIPTION
This adds the plumbing needed to inspect the vote bits of a ssgen (vote) transaction and determine the vote version, last block validity and block voted on, and choices made on any agendas for the vote version.

The partially addresses Issue https://github.com/dcrdata/dcrdata/issues/141.  Some UI design is needed to complete it.

Functions added:
- SSGenVoteBlockValid
- VoteBitsInBlock
- SSGenVoteBits
- SSGenVoteChoices

structs added:
- BlockValidation
- VoteChoice