### PR TITLE
format explorer numbers with commas (WIP)

### DIFF
--- a/explorer.go
+++ b/explorer.go
@@ -10,15 +10,15 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/decred/dcrutil"
-
 	apitypes "github.com/dcrdata/dcrdata/dcrdataapi"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson"
-
+	"github.com/decred/dcrutil"
+	
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 	"github.com/rs/cors"
+	"github.com/dustin/go-humanize"
 )
 
 const (
@@ -290,6 +290,25 @@ func newExplorerMux(app *appContext, userRealIP bool) *explorerUI {
 	exp.templateFiles["extras"] = filepath.Join("views", "extras.tmpl")
 
 	exp.templateHelpers = template.FuncMap{
+		"uint32Comma": func(v uint32) string {
+			i64 := int64(v)
+			return humanize.Comma(i64)
+		},
+		"int64Comma": func(v int64) string {
+			t := humanize.Comma(v)
+			return t
+		},
+		"float64Commaf": func(v float64) string {
+			return humanize.Commaf(v)
+		},
+		"formatBytes": func(v int32) string {
+			i64 := uint64(v)
+			return humanize.Bytes(i64)
+		},
+		"formatBytesInt": func(v int) string {
+			i64 := uint64(v)
+			return humanize.Bytes(i64)
+		},
 		"timezone": func() string {
 			t, _ := time.Now().Zone()
 			return t
@@ -319,7 +338,7 @@ func newExplorerMux(app *appContext, userRealIP bool) *explorerUI {
 		"size": func(h string) int {
 			return len(h) / 2
 		},
-		"totalSentInBlock": func(block *apitypes.BlockDataWithTxType) dcrutil.Amount {
+		"totalSentInBlock": func(block *apitypes.BlockDataWithTxType) string {
 			var total float64
 			for _, i := range block.RawTx {
 				for _, j := range i.Vout {
@@ -331,8 +350,7 @@ func newExplorerMux(app *appContext, userRealIP bool) *explorerUI {
 					total = total + j.Value
 				}
 			}
-			amount, _ := dcrutil.NewAmount(total)
-			return amount
+			return humanize.Commaf(total) + " DCR"
 		},
 	}
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d3f6dd204a93cf31bf583b4f386477a76ec227a748683fa9bb03cb6bb3c6575a
-updated: 2017-09-13T02:11:09.518968752+02:00
+hash: f5c28732361293a4532bbf42fd9fcd10981304a404969e7cec51b58f4aa54108
+updated: 2017-09-13T21:44:38.255121694-07:00
 imports:
 - name: github.com/agl/ed25519
   version: 278e1ec8e8a6e017cd07577924d6766039146ced
@@ -75,6 +75,8 @@ imports:
   - snacl
   - wallet/udb
   - walletdb
+- name: github.com/dustin/go-humanize
+  version: 79e699ccd02f240a1f1fbbdcee7e64c1c12e41aa
 - name: github.com/go-chi/chi
   version: 967844826e58cf31213a7dfb82455d242ad85101
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -31,3 +31,4 @@ import:
   version: ~3.0.0
 - package: github.com/rs/cors
   version: ~1.1.0
+- package: github.com/dustin/go-humanize

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -17,7 +17,7 @@
                 <table class="table table-sm striped">
                     <thead>
                         <th>Transactions ID</th>
-                        <th>Total Value</th>
+                        <th>Total DCR</th>
                         <th>Time</th>
                         <th>Age</th>
                         <th>Confirmations</th>
@@ -27,7 +27,7 @@
                         {{range .Transactions}}
                         <tr>
                             <td><a href="../tx/{{.TxID}}" class="hash collapse">{{.TxID}}</a></td>
-                            <td>{{.Value | getAmount}}</td>
+                            <td>{{.Value | float64Commaf}}</td>
                             <td>{{.Time | getTime }}</td>
                             <td class="age">{{if eq .Time 0}}
                                 N/A
@@ -36,8 +36,8 @@
                             {{end}}
                             </td>
                             <td class="hidden">{{.Time}}</td>
-                            <td>{{.Confirmations}}</td>
-                            <td>{{.Size}} B</td>
+                            <td>{{.Confirmations | int64Comma}}</td>
+                            <td>{{.Size | formatBytes}} B</td>
                         </tr>
                         {{end}}
                     </tbody>

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -18,11 +18,11 @@
                     </tr>
                     <tr>
                         <td>Height</td>
-                        <td>{{.Height}}</td>
+                        <td>{{.Height | int64Comma}}</td>
                     </tr>
                     <tr>
                         <td>Size</td>
-                        <td>{{.Size}} B</td>
+                        <td>{{.Size | formatBytes}}</td>
                     </tr>
                     <tr>
                         <td>Confirmations</td>
@@ -34,7 +34,7 @@
                     </tr>
                     <tr>
                         <td>Difficulty</td>
-                        <td>{{printf "%12.2f" .Difficulty}}</td>
+                        <td>{{.Difficulty | float64Commaf}}</td>
                     </tr>
                     <tr>
                         <td>POS Difficulty(Sbits)</td>
@@ -106,7 +106,7 @@
                     </tr>
                     <tr>
                         <td>Pool Size</td>
-                        <td>{{.PoolSize}}</td>
+                        <td>{{.PoolSize | uint32Comma}}</td>
                     </tr>
                     <tr>
                         <td>Nonce</td>
@@ -132,7 +132,7 @@
                 <table class="table table-sm striped">
                     <thead>
                         <th>Transactions ID</th>
-                        <th>Total Value</th>
+                        <th>Total DCR</th>
                         <th>Size</th>
                         <th>Type</th>
                     </thead>
@@ -144,8 +144,8 @@
                                     <a class="hash" href="/explorer/tx/{{.Txid}}">{{.Txid}}</a>
                                 </span>
                             </td>
-                            <td>{{ .Vout | getTotalFromBlock | getAmount}}</td>
-                            <td>{{.Hex | size}} B</td>
+                            <td>{{ .Vout | getTotalFromBlock | float64Commaf}}</td>
+                            <td>{{.Hex | size | formatBytesInt}}</td>
                             <td>{{.TxType}}</td>
                         </tr>
                         {{end}}
@@ -160,7 +160,7 @@
                 <table class="table table-sm striped">
                     <thead>
                         <th>Transactions ID</th>
-                        <th>Total Value</th>
+                        <th>Total DCR</th>
                         <th>Size</th>
                     </thead>
                     <tbody>
@@ -171,8 +171,8 @@
                                     <a class="hash" href="/explorer/tx/{{.Txid}}">{{.Txid}}</a>
                                 </span>
                             </td>
-                            <td>{{ .Vout | getTotalFromBlock | getAmount}}</td>
-                            <td>{{.Hex | size}} B</td>
+                            <td>{{ .Vout | getTotalFromBlock | float64Commaf}}</td>
+                            <td>{{.Hex | size | formatBytesInt}}</td>
                         </tr>
                         {{end}}
                     </tbody>

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -37,13 +37,13 @@
                     </thead>
                     <tbody>
                     {{range .Data}}
-                        <tr id="{{.Height}}">
-                            <td><a href="/explorer/block/{{.Hash}}" class="height">{{.Height}}</a></td>
+                        <tr id="{{ .Height }}">
+                            <td><a href="/explorer/block/{{.Hash}}" class="height">{{ .Height | int64Comma }}</a></td>
                             <td>{{.Voters}}</td>
                             <td>{{.FreshStake}}</td>
                             <td>{{len .Tx}}</td>
                             <td>{{.Revocations}}</td>
-                            <td>{{.Size}} B</td>
+                            <td>{{.Size | formatBytes}}</td>
                             <td class="age">{{.Time}}</td>
                             <td class="hidden">{{.Time}}</td>
                             <td>{{.Time | getTime}}</td>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -13,7 +13,7 @@
             <table class="table">
                 <thead>
                     <th>Transactions ID</th>
-                    <th>Total Value</th>
+                    <th>Total DCR</th>
                     <th>Time</th>
                     <th>Age</th>
                     <th>Confirmations</th>
@@ -26,7 +26,7 @@
                     <tr>
                         <td><span class="hash collapse">{{.TxID}}</span></td>
 
-                        <td>{{ .Vout | getTotalFromTx | getAmount}}</td>
+                        <td>{{ .Vout | getTotalFromTx | float64Commaf}}</td>
                         <td>
                         {{if eq $.Block.Time 0}}
                             N/A
@@ -44,7 +44,7 @@
                         {{if eq $.Confirmations 0}}
                             Unconfirmed
                         {{else}}
-                            {{$.Confirmations}}
+                            {{$.Confirmations | int64Comma}}
                         {{end}}
                         </td>
 
@@ -52,10 +52,10 @@
                         {{if eq $.Block.BlockHeight 0}}
                             N/A
                         {{else}}
-                            <a href="/explorer/block/{{$.Block.BlockHash}}">{{$.Block.BlockHeight}}</a></td>
+                            <a href="/explorer/block/{{$.Block.BlockHash}}">{{$.Block.BlockHeight | int64Comma}}</a></td>
                         {{end}}
                         <td>{{$.Type}}</td>
-                        <td>{{.Size}} B</td>
+                        <td>{{.Size | formatBytes}} B</td>
                     </tr>
                     {{end}}
                 </tbody>
@@ -71,7 +71,7 @@
                     <th>Addresses</th>
                     <!-- <th>Tree</th> -->
                     <th class="nowrap">Block</th>
-                    <th>Value</th>
+                    <th>DCR</th>
                 </thead>
                 <tbody>
                     {{range $i, $vin := .Vin}}
@@ -99,10 +99,10 @@
                         {{if eq $vin.BlockHeight 0}}
                             N/A
                         {{else}}
-                            <a href="/explorer/block/{{$.Block.BlockHash}}">{{$vin.BlockHeight}}</a></td>
+                            <a href="/explorer/block/{{$.Block.BlockHash}}">{{$vin.BlockHeight | uint32Comma}}</a></td>
                         {{end}}
                         </td>
-                        <td>{{if lt $vin.AmountIn 0.0}} N/A {{else}} {{getAmount $vin.AmountIn}} {{end}}</td>
+                        <td>{{if lt $vin.AmountIn 0.0}} N/A {{else}} {{float64Commaf $vin.AmountIn}} {{end}}</td>
                     </tr>
                     {{end}}
                 </tbody>
@@ -112,7 +112,7 @@
             <h4>Out</h4>
             <table class="table striped">
                 <thead>
-                    <th>Value</th>
+                    <th>DCR</th>
                     <th>Address</th>
                 </thead>
                 <tbody>
@@ -120,7 +120,7 @@
                     {{ if ne .Value 0.0}}
                     <tr>
                         <td>
-                            {{.Value | getAmount}}
+                            {{.Value | float64Commaf}}
                         </td>
                         <td>
                             {{range .ScriptPubKeyDecoded.Addresses}}


### PR DESCRIPTION
This change imports the go-humanize lib to:

- format various kinds of numbers with commas in the explorer.
- formats bytes so that it shows in "kB" or "B" depending on size.
- Instead of printing out 'DCR' in every cell, use the column header to label the unit

What is the preferred way to share these functions so they can also be used in root.tmpl?

