### PR TITLE
Tweak logging levels and error messages

### DIFF
--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -112,7 +112,7 @@ func (db *wiredDB) GetBestBlockHash() (string, error) {
 	hash := db.DBDataSaver.GetBestBlockHash()
 	var err error
 	if len(hash) == 0 {
-		err = fmt.Errorf("Unable to get best block hash")
+		err = fmt.Errorf("unable to get best block hash")
 	}
 	return hash, err
 }
@@ -120,7 +120,7 @@ func (db *wiredDB) GetBestBlockHash() (string, error) {
 func (db *wiredDB) GetBlockHash(idx int64) (string, error) {
 	hash, err := db.RetrieveBlockHash(idx)
 	if err != nil {
-		log.Errorf("Unable to block hash for index %d: %v", idx, err)
+		log.Errorf("Unable to get block hash for block number %d: %v", idx, err)
 		return "", err
 	}
 	return hash, nil
@@ -129,7 +129,7 @@ func (db *wiredDB) GetBlockHash(idx int64) (string, error) {
 func (db *wiredDB) GetBlockHeight(hash string) (int64, error) {
 	height, err := db.RetrieveBlockHeight(hash)
 	if err != nil {
-		log.Errorf("Unable to block height for hash %s: %v", hash, err)
+		log.Errorf("Unable to get block height for hash %s: %v", hash, err)
 		return -1, err
 	}
 	return height, nil

--- a/dcrsqlite/chainmonitor.go
+++ b/dcrsqlite/chainmonitor.go
@@ -198,7 +198,7 @@ func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 	// Retrieve height of chain in sqlite DB, and hash of best block
 	bestBlockSummary := p.db.GetBestBlockSummary()
 	if bestBlockSummary == nil {
-		return 0, nil, fmt.Errorf("Unable to retrieve best block summary")
+		return 0, nil, fmt.Errorf("unable to retrieve best block summary")
 	}
 	height := bestBlockSummary.Height
 	hash, err := chainhash.NewHashFromStr(bestBlockSummary.Hash)

--- a/rpcutils/rpcclient.go
+++ b/rpcutils/rpcclient.go
@@ -56,7 +56,7 @@ func ConnectNodeRPC(host, user, pass, cert string, disableTLS bool,
 	var ntfnHdlrs *dcrrpcclient.NotificationHandlers
 	if len(ntfnHandlers) > 0 {
 		if len(ntfnHandlers) > 1 {
-			return nil, nodeVer, fmt.Errorf("Invalid notification handler argument")
+			return nil, nodeVer, fmt.Errorf("invalid notification handler argument")
 		}
 		ntfnHdlrs = ntfnHandlers[0]
 	}
@@ -69,7 +69,7 @@ func ConnectNodeRPC(host, user, pass, cert string, disableTLS bool,
 	ver, err := dcrdClient.Version()
 	if err != nil {
 		log.Error("Unable to get RPC version: ", err)
-		return nil, nodeVer, fmt.Errorf("Unable to get node RPC version")
+		return nil, nodeVer, fmt.Errorf("unable to get node RPC version")
 	}
 
 	dcrdVer := ver["dcrdjsonrpcapi"]

--- a/txhelpers/txhelpers_test.go
+++ b/txhelpers/txhelpers_test.go
@@ -182,7 +182,7 @@ func ConnectNodeRPC(host, user, pass, cert string, disableTLS bool) (*dcrrpcclie
 	// Ensure the RPC server has a compatible API version.
 	ver, err := dcrdClient.Version()
 	if err != nil {
-		return nil, nodeVer, fmt.Errorf("Unable to get node RPC version")
+		return nil, nodeVer, fmt.Errorf("unable to get node RPC version")
 	}
 
 	dcrdVer := ver["dcrdjsonrpcapi"]

--- a/web.go
+++ b/web.go
@@ -324,7 +324,7 @@ func (td *WebUI) WSBlockUpdater(w http.ResponseWriter, r *http.Request) {
 				err := websocket.JSON.Send(ws, webData)
 				td.templateDataMtx.RUnlock()
 				if err != nil {
-					log.Warnf("Failed to encode WebSocketMessage %v: %v", sig, err)
+					log.Debugf("Failed to encode WebSocketMessage %v: %v", sig, err)
 					// If the send failed, the client is probably gone, so close
 					// the connection and quit.
 					return


### PR DESCRIPTION
In general, the string in error types should be lowercase.  But when there is printf-style formatting going on, particularly with sentence structure, I think it's OK to have some capitalization as it's probably just going to a log message.