### PR TITLE
Plug APICache into dcrsqlite.wiredDB (TESTING)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.log.*.gz
 *.bak
 debug
+debug.test
 *.cert
 *.key
 dcrdata

--- a/dcrdataapi/apicache.go
+++ b/dcrdataapi/apicache.go
@@ -164,6 +164,7 @@ func (apic *APICache) StoreBlockSummary(blockSummary *BlockDataBasic) error {
 	// Insert into queue and delete any cached block that was removed
 	wasAdded, removedBlock := apic.expireQueue.Insert(blockSummary)
 	if removedBlock != nil {
+		apic.blockCache[*removedBlock] = nil
 		delete(apic.blockCache, *removedBlock)
 	}
 
@@ -184,6 +185,7 @@ func (apic *APICache) RemoveCachedBlock(cachedBlock *CachedBlock) {
 	apic.expireQueue.RemoveBlock(cachedBlock)
 	// remove from block cache
 	if hash, err := chainhash.NewHashFromStr(cachedBlock.summary.Hash); err != nil {
+		apic.blockCache[*hash] = nil
 		delete(apic.blockCache, *hash)
 	}
 }

--- a/dcrdataapi/apicache.go
+++ b/dcrdataapi/apicache.go
@@ -193,7 +193,7 @@ func (apic *APICache) RemoveCachedBlock(cachedBlock *CachedBlock) {
 // GetBlockSummary attempts to retrieve the block summary for the input height.
 // The return is nil if no block with that height is cached.
 func (apic *APICache) GetBlockSummary(height int64) *BlockDataBasic {
-	cachedBlock := apic.GetCachedBlockByHeight(height)
+	cachedBlock, _ := apic.GetCachedBlockByHeight(height)
 	if cachedBlock != nil {
 		return cachedBlock.summary
 	}
@@ -202,11 +202,11 @@ func (apic *APICache) GetBlockSummary(height int64) *BlockDataBasic {
 
 // GetCachedBlockByHeight attempts to fetch a CachedBlock with the given height.
 // The return is nil if no block with that height is cached.
-func (apic *APICache) GetCachedBlockByHeight(height int64) *CachedBlock {
+func (apic *APICache) GetCachedBlockByHeight(height int64) (*CachedBlock, error) {
 	apic.RLock()
 	if int(height) >= len(apic.MainchainBlocks) || height < 0 {
-		fmt.Printf("block not in MainchainBlocks slice!")
-		return nil
+		apic.RUnlock()
+		return nil, fmt.Errorf("block not in MainchainBlocks slice")
 	}
 	hash := apic.MainchainBlocks[height]
 	apic.RUnlock()
@@ -215,34 +215,31 @@ func (apic *APICache) GetCachedBlockByHeight(height int64) *CachedBlock {
 
 // GetCachedBlockByHashStr attempts to fetch a CachedBlock with the given hash.
 // The return is nil if no block with that hash is cached.
-func (apic *APICache) GetCachedBlockByHashStr(hashStr string) *CachedBlock {
+func (apic *APICache) GetCachedBlockByHashStr(hashStr string) (*CachedBlock, error) {
 	// Validate the hash string, and get a *chainhash.Hash
 	hash, err := chainhash.NewHashFromStr(hashStr)
 	if err != nil {
-		fmt.Printf("that's not a real hash!")
-		return nil
+		return nil, fmt.Errorf("invalid hash string: %v", err)
 	}
 
-	return apic.getCachedBlockByHash(*hash)
+	return apic.getCachedBlockByHash(*hash), nil
 }
 
 // GetCachedBlockByHash attempts to fetch a CachedBlock with the given hash. The
 // return is nil if no block with that hash is cached.
-func (apic *APICache) GetCachedBlockByHash(hash chainhash.Hash) *CachedBlock {
+func (apic *APICache) GetCachedBlockByHash(hash chainhash.Hash) (*CachedBlock, error) {
 	// validate the chainhash.Hash
 	if _, err := chainhash.NewHashFromStr(hash.String()); err != nil {
-		fmt.Printf("that's not a real hash!")
-		return nil
+		return nil, fmt.Errorf("invalid chainhash.Hash: %v", err)
 	}
 
-	return apic.getCachedBlockByHash(hash)
+	return apic.getCachedBlockByHash(hash), nil
 }
 
 // getCachedBlockByHash retrieves the block with the given hash, or nil if it is
 // not found. Successful retrieval will update the cached block's access time,
 // and increment the block's access count.
 func (apic *APICache) getCachedBlockByHash(hash chainhash.Hash) *CachedBlock {
-
 	apic.Lock()
 	defer apic.Unlock()
 

--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -26,15 +26,18 @@ import (
 // not stored in the DB, so the RPC client is used to get it on demand.
 type wiredDB struct {
 	*DBDataSaver
-	MPC    *mempool.MempoolDataCache
-	client *dcrrpcclient.Client
-	params *chaincfg.Params
-	sDB    *stakedb.StakeDatabase
+	APICache *apitypes.APICache
+	MPC      *mempool.MempoolDataCache
+	client   *dcrrpcclient.Client
+	params   *chaincfg.Params
+	sDB      *stakedb.StakeDatabase
 }
 
 func newWiredDB(DB *DB, statusC chan uint32, cl *dcrrpcclient.Client, p *chaincfg.Params) (wiredDB, func() error) {
+	apic := apitypes.NewAPICache(50000)
 	wDB := wiredDB{
-		DBDataSaver: &DBDataSaver{DB, statusC},
+		DBDataSaver: &DBDataSaver{DB, statusC, apic},
+		APICache:    apic,
 		MPC:         new(mempool.MempoolDataCache),
 		client:      cl,
 		params:      p,
@@ -47,6 +50,12 @@ func newWiredDB(DB *DB, statusC chan uint32, cl *dcrrpcclient.Client, p *chaincf
 		log.Errorf("Unable to create stake DB: %v", err)
 		return wDB, func() error { return nil }
 	}
+
+	log.Info("Generating main chain block map...")
+	if err = wDB.buildMainchainBlockMap(); err != nil {
+		panic(fmt.Sprintf("Unable to build mainchain block map: %v", err))
+	}
+
 	return wDB, wDB.sDB.StakeDB.Close
 }
 
@@ -67,6 +76,34 @@ func InitWiredDB(dbInfo *DBInfo, statusC chan uint32, cl *dcrrpcclient.Client, p
 
 	wDB, cleanup := newWiredDB(db, statusC, cl, p)
 	return wDB, cleanup, nil
+}
+
+func (db *wiredDB) buildMainchainBlockMap() error {
+	if db.APICache == nil {
+		return fmt.Errorf("API cache disabled, unable to build MainchainBlock map")
+	}
+
+	dbHeight := db.dbSummaryHeight
+
+	db.APICache.MainchainBlocks = make([]chainhash.Hash, 0, dbHeight+20000)
+
+	for i := int64(0); i <= dbHeight; i++ {
+		hashStr, err := db.RetrieveBlockHash(i)
+		if err != nil {
+			log.Errorf("Unable to get block hash for index %d: %v", i, err)
+			return err
+		}
+
+		hash, err := chainhash.NewHashFromStr(hashStr)
+		if err != nil {
+			log.Errorf("Invalid hash (%s) stored in DB for index %d: %v", hashStr, i, err)
+			return err
+		}
+
+		db.APICache.MainchainBlocks = append(db.APICache.MainchainBlocks, *hash)
+	}
+
+	return nil
 }
 
 func (db *wiredDB) NewStakeDBChainMonitor(quit chan struct{}, wg *sync.WaitGroup,
@@ -415,6 +452,16 @@ func (db *wiredDB) GetVoteInfo(txid string) (*apitypes.VoteInfo, error) {
 	return vinfo, nil
 }
 
+func (db *wiredDB) GetHash(idx int64) (string, error) {
+	hash, err := db.RetrieveBlockHash(idx)
+	if err != nil {
+		log.Errorf("Unable to block hash for index %d: %v", idx, err)
+		return "", err
+	}
+
+	return hash, nil
+}
+
 func (db *wiredDB) GetStakeDiffEstimates() *apitypes.StakeDiff {
 	sd := rpcutils.GetStakeDiffEstimates(db.client)
 
@@ -447,10 +494,29 @@ func (db *wiredDB) GetStakeInfoExtended(idx int) *apitypes.StakeInfoExtended {
 }
 
 func (db *wiredDB) GetSummary(idx int) *apitypes.BlockDataBasic {
-	blockSummary, err := db.RetrieveBlockSummary(int64(idx))
+	var blockSummary *apitypes.BlockDataBasic
+
+	if db.APICache != nil {
+		blockSummary = db.APICache.GetBlockSummary(int64(idx))
+		if blockSummary != nil {
+			return blockSummary
+		}
+	}
+
+	var err error
+	blockSummary, err = db.RetrieveBlockSummary(int64(idx))
 	if err != nil {
 		log.Errorf("Unable to retrieve block summary: %v", err)
 		return nil
+	}
+
+	if db.APICache != nil {
+		if err = db.APICache.StoreBlockSummary(blockSummary); err != nil {
+			log.Warnf("Unable to store block summary in APICache: %v", err)
+		} else {
+			log.Tracef("Stored block in cache: %d / %v. Utilization: %v%%",
+				blockSummary.Height, blockSummary.Hash, db.APICache.Utilization())
+		}
 	}
 
 	return blockSummary

--- a/dcrsqlite/chainmonitor.go
+++ b/dcrsqlite/chainmonitor.go
@@ -190,8 +190,10 @@ func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 			// If a block was cached at this height already, it was from the
 			// previous mainchain, so remove it.
 			height := int64(blockDataSummary.Height)
-			if cachedBlock := p.db.APICache.GetCachedBlockByHeight(height); cachedBlock != nil {
+			if cachedBlock, err := p.db.APICache.GetCachedBlockByHeight(height); cachedBlock != nil {
 				p.db.APICache.RemoveCachedBlock(cachedBlock)
+			} else {
+				log.Warnf("No cached block at height %d: %v", height, err)
 			}
 			// Store block summary in a new cached block
 			if err := p.db.APICache.StoreBlockSummary(blockDataSummary); err != nil {

--- a/dcrsqlite/chainmonitor.go
+++ b/dcrsqlite/chainmonitor.go
@@ -185,6 +185,23 @@ func (p *ChainMonitor) switchToSideChain() (int32, *chainhash.Hash, error) {
 			log.Error("Failed to collect data for reorg.")
 			continue
 		}
+		// Cache
+		if p.db.APICache != nil {
+			// If a block was cached at this height already, it was from the
+			// previous mainchain, so remove it.
+			height := int64(blockDataSummary.Height)
+			if cachedBlock := p.db.APICache.GetCachedBlockByHeight(height); cachedBlock != nil {
+				p.db.APICache.RemoveCachedBlock(cachedBlock)
+			}
+			// Store block summary in a new cached block
+			if err := p.db.APICache.StoreBlockSummary(blockDataSummary); err != nil {
+				log.Warn("Unable to store block summary in cache:", err)
+			} else {
+				log.Debugf("Stored block in cache: %d / %v. Utilization: %v%%",
+					blockDataSummary.Height, blockDataSummary.Hash, p.db.APICache.Utilization())
+			}
+		}
+		// DB
 		if err := p.db.StoreBlockSummary(blockDataSummary); err != nil {
 			log.Errorf("Failed to store block summary data: %v", err)
 		}

--- a/dcrsqlite/sync.go
+++ b/dcrsqlite/sync.go
@@ -16,7 +16,7 @@ import (
 const (
 	rescanLogBlockChunk = 250
 	// dbType is the database backend type to use
-	dbType = "ffldb"
+	// dbType = "ffldb" // currently unused
 	// DefaultStakeDbName is the default database name
 	DefaultStakeDbName = "ffldb_stake"
 )
@@ -92,6 +92,16 @@ func (db *wiredDB) resyncDB(quit chan struct{}) error {
 			},
 		}
 
+		freeCache := int64(db.APICache.Capacity()) - db.APICache.UtilizationBlocks()
+		remainingBlocks := i - height
+		if db.APICache != nil && remainingBlocks <= freeCache {
+			if err = db.APICache.StoreBlockSummary(&blockSummary); err != nil {
+				log.Warn("Unable to store block summary in cache:", err)
+			} else if (i-1)%rescanLogBlockChunk == 0 || i == startHeight {
+				log.Debugf("Stored block in cache: %d / %v. Utilization: %v%%",
+					blockSummary.Height, blockSummary.Hash, db.APICache.Utilization())
+			}
+		}
 		if err = db.StoreBlockSummary(&blockSummary); err != nil {
 			return fmt.Errorf("Unable to store block summary in database: %v", err)
 		}
@@ -277,6 +287,15 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) error {
 			StakeDiff:  dcrutil.Amount(header.SBits).ToCoin(),
 			Time:       header.Timestamp.Unix(),
 			PoolInfo:   *tpi,
+		}
+
+		if db.APICache != nil {
+			if err = db.APICache.StoreBlockSummary(&blockSummary); err != nil {
+				log.Warn("Unable to store block summary in cache:", err)
+			} else if (i-1)%rescanLogBlockChunk == 0 || i == startHeight {
+				log.Debugf("Stored block in cache: %d / %v. Utilization: %v%%",
+					blockSummary.Height, blockSummary.Hash, db.APICache.Utilization())
+			}
 		}
 
 		if i > bestBlockHeight {

--- a/explorer.go
+++ b/explorer.go
@@ -14,11 +14,10 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrutil"
-	
+	"github.com/dustin/go-humanize"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 	"github.com/rs/cors"
-	"github.com/dustin/go-humanize"
 )
 
 const (
@@ -28,7 +27,7 @@ const (
 	addressTemplateIndex
 	maxExplorerRows = 2000
 	minExplorerRows = 20
-	addressRows     = 2000
+	addressRows     = 1200
 )
 
 type explorerUI struct {

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -188,6 +188,7 @@ func (db *StakeDatabase) block(ind int64) (*dcrutil.Block, bool) {
 func (db *StakeDatabase) ForgetBlock(ind int64) {
 	db.blkMtx.Lock()
 	defer db.blkMtx.Unlock()
+	db.blockCache[ind] = nil
 	delete(db.blockCache, ind)
 }
 


### PR DESCRIPTION
Plug the new APICache into dcrsqlite.wireDB to have a block data cache.

Add wiredDB.GetHash, which uses dcrsqlite.RetrieveBlockHash.