### PR TITLE
Layout tweaks

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -83,6 +83,13 @@ h4 {
 .nowrap {
   white-space: nowrap;
 }
+.break-word {
+  word-wrap: break-word;
+  word-break: break-word;
+}
+.mono {
+  font-family: monospace;
+}
 .fs12 {
   font-size: 12px
 }
@@ -182,29 +189,6 @@ h4 {
   display: inline-block;
   width: 198px;
 }
-.address {
-  font-family: monospace;
-  display: inline-block;
-  word-wrap: break-word;
-  transition: .133s transform;
-}
-.address.collapse {
-  font-size: 10px;
-  display: inline-block;
-  width: 211px;
-}
-
-.outpoint {
-  font-family: monospace;
-  display: inline-block;
-  word-wrap: break-word;
-  transition: .133s transform;
-}
-.outpoint.collapse {
-  font-size: 10px;
-  display: inline-block;
-  width: 206px;
-}
 
 /*responsive*/
 @media only screen and (max-width: 992px)  {
@@ -216,16 +200,10 @@ h4 {
   .hash.collapse {
     width: 142px;
   }
-  .address.collapse {
-    width: 142px;
-  }
 }
 @media only screen and (max-width: 768px)  {
   .hash.collapse {
     width: 198px;
-  }
-  .address.collapse {
-    width: 110px;
   }
   .table {
     margin-bottom: 0;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -64,6 +64,7 @@ html {
   -webkit-font-smoothing: antialiased !important;
   -moz-font-smoothing: antialiased !important;
   text-rendering: optimizelegibility !important;
+  padding-top: 30px;
 }
 body {
   padding-bottom: 2.1rem;
@@ -93,10 +94,15 @@ h4 {
 /*nav*/
 .top-nav,
 .navbar-fixed-bottom {
+  position: fixed;
   background: #3B3F45;
+  z-index: 1;
+}
+.top-nav {
+  width: 100%;
+  top: 0;
 }
 .navbar-fixed-bottom {
-  position: fixed;
   bottom: 0;
   width: 100%;
   color: silver;
@@ -176,6 +182,17 @@ h4 {
   display: inline-block;
   width: 198px;
 }
+.address {
+  font-family: monospace;
+  display: inline-block;
+  word-wrap: break-word;
+  transition: .133s transform;
+}
+.address.collapse {
+  font-size: 10px;
+  display: inline-block;
+  width: 211px;
+}
 
 .outpoint {
   font-family: monospace;
@@ -199,10 +216,16 @@ h4 {
   .hash.collapse {
     width: 142px;
   }
+  .address.collapse {
+    width: 142px;
+  }
 }
 @media only screen and (max-width: 768px)  {
   .hash.collapse {
     width: 198px;
+  }
+  .address.collapse {
+    width: 110px;
   }
   .table {
     margin-bottom: 0;

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -22,14 +22,20 @@
 
         <div class="row">
             <div class="col-md-12">
-                <table class="table striped">
+                <table class="table striped table-responsive">
                     <thead>
                         <tr>
                             <th>Height</th>
-                            <th>Votes</th>
-                            <th>Tickets</th>
-                            <th>Transactions</th>
-                            <th>Revocations</th>
+                            <th>
+                                <span class="d-none d-md-inline">Transactions</span>
+                                <span class="d-md-none">Txn</span>
+                            </th>
+                            <th>Vote<span class="d-none d-md-inline">s</span></th>
+                            <th>Ticket<span class="d-none d-md-inline">s</span></th>
+                            <th>
+                                <span class="d-none d-md-inline">Revocations</span>
+                                <span class="d-md-none">Revoke</span>
+                            </th>
                             <th>Size</th>
                             <th>Age</th>
                             <th>Time ({{timezone}})</th>
@@ -39,9 +45,9 @@
                     {{range .Data}}
                         <tr id="{{ .Height }}">
                             <td><a href="/explorer/block/{{.Hash}}" class="height">{{ .Height | int64Comma }}</a></td>
+                            <td>{{len .Tx}}</td>
                             <td>{{.Voters}}</td>
                             <td>{{.FreshStake}}</td>
-                            <td>{{len .Tx}}</td>
                             <td>{{.Revocations}}</td>
                             <td>{{.Size | formatBytes}}</td>
                             <td class="age">{{.Time}}</td>
@@ -57,8 +63,8 @@
 
     <script>
         var heights = document.getElementsByClassName("height");
-        var first = parseInt(heights[0].innerText);
-        var last = parseInt(heights[heights.length-1].innerText);
+        var first = parseInt(heights[0].innerText.replace(/,/g, ''));
+        var last = parseInt(heights[heights.length-1].innerText.replace(/,/g, ''));
         var numBlocks = first - last + 1;
         var prev = document.getElementById("prev");
         var next = document.getElementById("next");

--- a/views/root.tmpl
+++ b/views/root.tmpl
@@ -216,7 +216,7 @@
         setInterval(function () {
             ws.send("ping", 'Hi. I am a client!');
         }, 1000);
-        
+
 	    function updateConnectionStatus(msg, connected) {
             var el = document.getElementById('connection');
             if (el.classList) {
@@ -357,13 +357,13 @@
 <script>
     var bsdev = document.getElementById("bsubsidy_dev");
     bsdev.innerHTML = subsidyToString(bsdev.innerHTML);
-                        
+
     var bspos = document.getElementById("bsubsidy_pos");
     bspos.innerHTML = subsidyToString(bspos.innerHTML, 5);
-                        
+
     var bspow = document.getElementById("bsubsidy_pow");
     bspow.innerHTML = subsidyToString(bspow.innerHTML);
-                        
+
     var bstotal = document.getElementById("bsubsidy_total");
     bstotal.innerHTML = subsidyToString(bstotal.innerHTML);
 </script>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -9,7 +9,7 @@
     <div class="row">
         <div class="col-md-12">
             <h4>Transaction</h4>
-            <p>{{.TxID}}   <span style="font-size: 12px;"><a href="/api/tx/{{.TxID}}?indent=true">view raw</a></span></p>
+            <p class="break-word">{{.TxID}} <a class="fs12" href="/api/tx/{{.TxID}}?indent=true">view raw</a></p>
             <table class="table">
                 <thead>
                     <th>Total DCR</th>
@@ -57,6 +57,10 @@
                     {{end}}
                 </tbody>
             </table>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-7">
             <h4>In</h4>
             <table class="table table-sm striped">
                 <thead>
@@ -75,13 +79,13 @@
                             {{else if eq $vin.Txid "0000000000000000000000000000000000000000000000000000000000000000"}}
                                 Vote Reward
                             {{else}}
-                            <a href="/explorer/tx/{{$vin.Txid}}"><span class="outpoint collapse">{{$vin.Txid}}:{{$vin.Vout}}</span></a>
+                            <a href="/explorer/tx/{{$vin.Txid}}"><span class="mono break-word">{{$vin.Txid}}:{{$vin.Vout}}</span></a>
                             {{end}}
                         </td>
-                        <td><div class="address collapse">
+                        <td><div>
                         {{with $as := index $.VinAddrs $i}}
                             {{if (len $as) gt 0}}
-                                <a href="/explorer/address/{{index $as 0}}">{{index $as 0}}</a>
+                                <a class="mono break-word" href="/explorer/address/{{index $as 0}}">{{index $as 0}}</a>
                             {{else}}
                                 N/A
                             {{end}}
@@ -100,6 +104,8 @@
                     {{end}}
                 </tbody>
             </table>
+        </div>
+        <div class="col-md-5">
             <h4>Out</h4>
             <table class="table striped">
                 <thead>
@@ -116,7 +122,7 @@
                         </td>
                         <td>
                             {{range .ScriptPubKeyDecoded.Addresses}}
-                                <div class="address"><a href="/explorer/address/{{.}}">{{.}}</a></div>
+                                <a class="mono break-word" href="/explorer/address/{{.}}">{{.}}</a>
                             {{end}}
                         </td>
                         <td>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -12,7 +12,6 @@
             <p>{{.TxID}}   <span style="font-size: 12px;"><a href="/api/tx/{{.TxID}}?indent=true">view raw</a></span></p>
             <table class="table">
                 <thead>
-                    <th>Transactions ID</th>
                     <th>Total DCR</th>
                     <th>Time</th>
                     <th>Age</th>
@@ -24,8 +23,6 @@
                 <tbody>
                     {{with .TxShort}}
                     <tr>
-                        <td><span class="hash collapse">{{.TxID}}</span></td>
-
                         <td>{{ .Vout | getTotalFromTx | float64Commaf}}</td>
                         <td>
                         {{if eq $.Block.Time 0}}
@@ -60,10 +57,6 @@
                     {{end}}
                 </tbody>
             </table>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-7">
             <h4>In</h4>
             <table class="table table-sm striped">
                 <thead>
@@ -85,10 +78,10 @@
                             <a href="/explorer/tx/{{$vin.Txid}}"><span class="outpoint collapse">{{$vin.Txid}}:{{$vin.Vout}}</span></a>
                             {{end}}
                         </td>
-                        <td><div class="hash">
+                        <td><div class="address collapse">
                         {{with $as := index $.VinAddrs $i}}
                             {{if (len $as) gt 0}}
-                                {{index $as 0}}
+                                <a href="/explorer/address/{{index $as 0}}">{{index $as 0}}</a>
                             {{else}}
                                 N/A
                             {{end}}
@@ -107,8 +100,6 @@
                     {{end}}
                 </tbody>
             </table>
-        </div>
-        <div class="col-md-5">
             <h4>Out</h4>
             <table class="table striped">
                 <thead>
@@ -125,7 +116,7 @@
                         </td>
                         <td>
                             {{range .ScriptPubKeyDecoded.Addresses}}
-                                <div class="hash"><a href="/explorer/address/{{.}}">{{.}}</a></div>
+                                <div class="address"><a href="/explorer/address/{{.}}">{{.}}</a></div>
                             {{end}}
                         </td>
                         <td>


### PR DESCRIPTION
- Explorer
Align styling and column order of explorer table with that of 6 blocks table in root.tmpl.
Fix prev/next links ( current logic is thrown off by commas in block heights )

- Transaction
Add Links to "In" addresses 
Splits address onto 2 lines on small screens

- Sticky Top Nav
Made the top nav sticky. The main reason for this to allow for a more flexible layout on small screens where the tables often overflow. Instead of making all the tables scroll within themselves when they don't fit. We can just let them expand the width of the page as needed this way. 