### PR TITLE
Show vote info and choices on Tx explorer page

### DIFF
--- a/apiroutes.go
+++ b/apiroutes.go
@@ -10,6 +10,7 @@ import (
 
 	apitypes "github.com/dcrdata/dcrdata/dcrdataapi"
 	"github.com/decred/dcrd/dcrjson"
+	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrrpcclient"
 )
 
@@ -25,7 +26,7 @@ type APIDataSource interface {
 	GetBlockVerboseByHash(hash string, verboseTx bool) *dcrjson.GetBlockVerboseResult
 	GetBlockVerboseWithStakeTxDetails(hash string) *apitypes.BlockDataWithTxType
 	GetRawTransaction(txid string) *apitypes.Tx
-	GetRawTransactionWithPrevOutAddresses(txid string) (*apitypes.Tx, [][]string, string)
+	GetRawTransactionWithPrevOutAddresses(txid string) (*apitypes.Tx, [][]string, string, *wire.MsgTx)
 	GetVoteInfo(txid string) (*apitypes.VoteInfo, error)
 	GetAllTxIn(txid string) []*apitypes.TxIn
 	GetAllTxOut(txid string) []*apitypes.TxOut

--- a/dcrdataapi/apitypes.go
+++ b/dcrdataapi/apitypes.go
@@ -47,6 +47,7 @@ type TxShort struct {
 type VoteInfo struct {
 	Validation BlockValidation         `json:"block_validation"`
 	Version    uint32                  `json:"vote_version"`
+	Bits       uint16                  `json:"vote_bits"`
 	Choices    []*txhelpers.VoteChoice `json:"vote_choices"`
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -190,6 +190,45 @@ h4 {
   width: 198px;
 }
 
+.outpoint {
+  font-family: monospace;
+  display: inline-block;
+  word-wrap: break-word;
+  transition: .133s transform;
+}
+.outpoint.collapse {
+  font-size: 10px;
+  display: inline-block;
+  width: 206px;
+}
+
+/*resemble voting.decred.org*/
+.highlight-text {
+  height: 20px;
+  margin-top: 3px;
+  padding-right: 4px;
+  padding-left: 4px;
+  border-radius: 3px;
+  line-height: 20px;
+  font-weight: 600;
+  background-color: rgba(105, 211, 245, .3);
+}
+.agenda-voting-overview-option-dot {
+  position: relative;
+  top: 2px;
+  width: 15px;
+  height: 15px;
+  margin-right: 6px;
+  float: left;
+  border-radius: 50%;
+}
+.agenda-voting-overview-option-dot._yes {
+  background-color: #2ed6a1;
+}
+.agenda-voting-overview-option-dot._no {
+  background-color: #2971ff;
+}
+
 /*responsive*/
 @media only screen and (max-width: 992px)  {
   .container {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -206,8 +206,7 @@ h4 {
 .highlight-text {
   height: 20px;
   margin-top: 3px;
-  padding-right: 4px;
-  padding-left: 4px;
+  padding: 2px 4px 3px;
   border-radius: 3px;
   line-height: 20px;
   font-weight: 600;

--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -394,14 +394,14 @@ type VoteChoice struct {
 }
 
 // SSGenVoteChoices gets a ssgen's vote choices (block validity and any
-// agendas). The vote's stake version is also returned, to which the vote
-// choices correspond. Note that []*VoteChoice may be an empty slice if there
-// are no consensus deployments for the transaction's vote version. The error
-// value may be non-nil if the tx is not a valid ssgen.
-func SSGenVoteChoices(tx *wire.MsgTx, params *chaincfg.Params) (BlockValidation, uint32, []*VoteChoice, error) {
+// agendas). The vote's stake version, to which the vote choices correspond, and
+// vote bits are also returned. Note that []*VoteChoice may be an empty slice if
+// there are no consensus deployments for the transaction's vote version. The
+// error value may be non-nil if the tx is not a valid ssgen.
+func SSGenVoteChoices(tx *wire.MsgTx, params *chaincfg.Params) (BlockValidation, uint32, uint16, []*VoteChoice, error) {
 	validBlock, voteBits, err := SSGenVoteBlockValid(tx)
 	if err != nil {
-		return validBlock, 0, nil, err
+		return validBlock, 0, 0, nil, err
 	}
 
 	// Determine the ssgen's vote version and get the relevent consensus
@@ -429,7 +429,7 @@ func SSGenVoteChoices(tx *wire.MsgTx, params *chaincfg.Params) (BlockValidation,
 		choices = append(choices, &voteChoice)
 	}
 
-	return validBlock, voteVersion, choices, nil
+	return validBlock, voteVersion, voteBits, choices, nil
 }
 
 // FeeInfoBlock computes ticket fee statistics for the tickets included in the

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -135,6 +135,34 @@
             </table>
         </div>
     </div>
+    {{if .VoteInfo}}
+    {{with .VoteInfo}}
+    <div class="row">
+        <div class="col-md-12">
+            <h4>Vote Info</h4>
+            <p>Version: {{.Version}} | Bits: {{printf "%#x" .Bits}}</p>
+            <table class="table striped">
+                <thead>
+                    <th>Issue ID</th>
+                    <th>Issue Description</th>
+                    <th>Choice ID</th>
+                    <th>Choice Description</th>
+                </thead>
+                <tbody>
+                    {{range .Choices}}
+                    <tr>
+                    <td>{{.ID}}</td>
+                    <td>{{.Description}}</td>
+                    <td>{{.Choice.Id}}</td>
+                    <td>{{.Choice.Description}}</td>
+                    </tr>
+                    {{end}}
+                </tbody>
+            </table>
+        </div>
+    </div>
+    {{end}}
+    {{end}}
 </div>
 
 {{template "footer"}}

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -143,7 +143,7 @@
             <p>Version: {{.Version}} | Bits: {{printf "%#x" .Bits}}</p>
             <table class="table striped">
                 <thead>
-                    <th>Issue ID</th>
+                    <th class="text-right">Issue ID</th>
                     <th>Issue Description</th>
                     <th>Choice ID</th>
                     <th>Choice Description</th>
@@ -151,10 +151,13 @@
                 <tbody>
                     {{range .Choices}}
                     <tr>
-                    <td>{{.ID}}</td>
-                    <td>{{.Description}}</td>
-                    <td>{{.Choice.Id}}</td>
-                    <td>{{.Choice.Description}}</td>
+                        <td class="text-right"><span class="highlight-text">{{.ID}}</span></td>
+                        <td>{{.Description}}</td>
+                        <td>
+                            <span class="agenda-voting-overview-option-dot _{{.Choice.Id}}"></span>
+                            {{.Choice.Id}}
+                        </td>
+                        <td>{{.Choice.Description}}</td>
                     </tr>
                     {{end}}
                 </tbody>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -140,7 +140,7 @@
     <div class="row">
         <div class="col-md-12">
             <h4>Vote Info</h4>
-            <p>Version: {{.Version}} | Bits: {{printf "%#x" .Bits}}</p>
+            <p>Version: {{.Version}} | Bits: {{printf "%#04x" .Bits}}</p>
             <table class="table striped">
                 <thead>
                     <th class="text-right">Issue ID</th>


### PR DESCRIPTION
- Create Vote Info table that displays on `/explorer/tx/...` for a ssgen.

  ![image](https://user-images.githubusercontent.com/9373513/30582099-1b4d5484-9ce8-11e7-98cd-76f7130337ee.png)

- Call `APIDataSource.GetVoteInfo` from `explorerUI.txPage` and execute the template with the vote info included in the existing template data struct.
- Add vote bits to `dcrdataapi.VoteInfo`.
- `txhelpers.SSGenVoteChoices` now returns vote bits too.
- `GetRawTransactionWithPrevOutAddresses` returns `*wire.MsgTx` as new 4th output argument.

Addresses Issue https://github.com/dcrdata/dcrdata/issues/141, but we should consider improved styling.