### PR TITLE
split layout 50/50 for tx.tmpl input/output tables

### DIFF
--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -84,7 +84,7 @@
     </div>
 
     <div class="row">
-        <div class="col-md-7 mb-3">
+        <div class="col-md-6 mb-3">
             <h4>Input</h4>
             <table class="table table-sm striped">
                 <thead>
@@ -129,7 +129,7 @@
                 </tbody>
             </table>
         </div>
-        <div class="col-md-5 mb-3">
+        <div class="col-md-6 mb-3">
             <h4>Output</h4>
             <table class="table table-sm striped">
                 <thead>


### PR DESCRIPTION
this simply splits the layout so its 50/50 which solves the one character overflow in output address when screen size is large.

before 
<img width="1155" alt="screen shot 2017-10-05 at 9 42 32 am" src="https://user-images.githubusercontent.com/25571523/31239342-a1aabc9e-a9b1-11e7-8b48-5753ff601f3e.png">

after
<img width="1138" alt="screen shot 2017-10-05 at 9 42 45 am" src="https://user-images.githubusercontent.com/25571523/31239347-a4969df6-a9b1-11e7-9d59-f10fde5a9aa9.png">

