### PR TITLE
Show block validity for ssgen, reintroduce BlockValidation type

### DIFF
--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -686,12 +686,17 @@ func makeExplorerTxBasic(data dcrjson.TxRawResult, msgTx *wire.MsgTx, params *ch
 	tx.FormattedTotal = humanize.Commaf(total)
 	tx.Fee, tx.FeeRate = txhelpers.TxFeeRate(msgTx)
 	if ok, _ := stake.IsSSGen(msgTx); ok {
-		_, version, bits, choices, err := txhelpers.SSGenVoteChoices(msgTx, params)
+		validation, version, bits, choices, err := txhelpers.SSGenVoteChoices(msgTx, params)
 		if err != nil {
 			log.Debugf("Cannot get vote choices for %s", tx.TxID)
 			return tx
 		}
 		tx.VoteInfo = &explorer.VoteInfo{
+			Validation: explorer.BlockValidation{
+				Hash:     validation.Hash.String(),
+				Height:   validation.Height,
+				Validity: validation.Validity,
+			},
 			Version: version,
 			Bits:    bits,
 			Choices: choices,

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -59,9 +59,17 @@ type TxInfo struct {
 
 // VoteInfo models data about a SSGen transaction (vote)
 type VoteInfo struct {
-	Version uint32                  `json:"vote_version"`
-	Bits    uint16                  `json:"vote_bits"`
-	Choices []*txhelpers.VoteChoice `json:"vote_choices"`
+	Validation BlockValidation         `json:"block_validation"`
+	Version    uint32                  `json:"vote_version"`
+	Bits       uint16                  `json:"vote_bits"`
+	Choices    []*txhelpers.VoteChoice `json:"vote_choices"`
+}
+
+// BlockValidation models data about a vote's decision on a block
+type BlockValidation struct {
+	Hash     string `json:"hash"`
+	Height   int64  `json:"height"`
+	Validity bool   `json:"validity"`
 }
 
 // Vin models basic data about a tx input for display

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -164,7 +164,8 @@
     <div class="row mb-3">
         <div class="col-md-12">
             <h4>Vote Info</h4>
-            <p>Version: <span class="mono">{{.Version}}</span> | Bits: <span class="mono">{{printf "%#04x" .Bits}}</span></p>
+            <p>Last Block Valid: <span class="mono"><strong>{{.Validation.Validity}}</strong></span><br>
+            Version: <span class="mono">{{.Version}}</span> | Bits: <span class="mono">{{printf "%#04x" .Bits}}</span></p>
             <table class="table striped">
                 <thead>
                     <th class="text-right">Issue ID</th>


### PR DESCRIPTION
Addresses issue https://github.com/dcrdata/dcrdata/issues/217

As usual, this is just terrible get-it-done web programming.  Sorry.