### PR TITLE
improve address formatting in tx.tmpl (fixes firefox issue as well)

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -251,6 +251,10 @@ body.darkBG .navbar-fixed-bottom a {
   font-family: 'inconsolata-v15-latin-regular';
   font-size: 14px;
 }
+.table .address {
+  max-width: 127px;
+  display: inline-block;
+}
 
 /*content*/
 .dcr-total .dcr {

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -96,19 +96,19 @@
                 <tbody>
                     {{range .Vin}}
                     <tr>
-                        <td>
+                        <td class="break-word">
                             {{if .Coinbase}}
                                 Coinbase: {{ .Coinbase }}
                             {{else if .Stakebase}}
                                 Stakebase: {{ .Stakebase }}
                             {{else}}
-                                <a href="/explorer/tx/{{.Txid}}"><span class="break-word">{{.Txid}}:{{.Vout}}</span></a>
+                                <a href="/explorer/tx/{{.Txid}}">{{.Txid}}:{{.Vout}}</a>
                             {{end}}
                         </td>
-                        <td><div>
+                        <td><div class="break-word address">
                             {{if gt (len .Addresses) 0}}
                                 {{range .Addresses}}
-                                    <a class="break-word" href="/explorer/address/{{.}}">{{.}}</a><br>
+                                    <a href="/explorer/address/{{.}}">{{.}}</a><br>
                                 {{end}}
                             {{else}}
                                 N/A
@@ -141,9 +141,9 @@
                     {{range .Vout}}
                     {{ if ne .Amount 0.0}}
                     <tr>
-                        <td>
+                        <td class="break-word">
                             {{range .Addresses}}
-                                <a class="break-word mono" href="/explorer/address/{{.}}">{{.}}</a><br>
+                                <a class="mono address" href="/explorer/address/{{.}}">{{.}}</a><br>
                             {{end}}
                         </td>
                         <td>


### PR DESCRIPTION
This fixes firefox layout issue by moving `break-word` class to the block level element, apparently Firefox calculates table cell widths a bit differently.

It PR also set a max-width on addresses in output table, so that in full screen width instead of only a few characters overflowing to next line, half of the address is on new line.

<img width="1142" alt="screen shot 2017-10-05 at 9 20 38 pm" src="https://user-images.githubusercontent.com/25571523/31262881-17eb9674-aa13-11e7-8db8-337468b768a9.png">
