### PR TITLE
fix bogus timestamp in 1st row of explorer.tmpl

### DIFF
--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -15,7 +15,7 @@
         <div class="row fs13">
             <div class="col d-flex justify-content-between">
                 <a id="prev" class="no-underline" href="/explorer">◄ Older</a>
-                <p id="best" class="hidden timestamp">{{.BestBlock}}</p>
+                <p id="best" class="hidden">{{.BestBlock}}</p>
                 <a id="next" class="no-underline" href="/explorer">Newer ►</a>
             </div>
         </div>


### PR DESCRIPTION
This fixes https://github.com/dcrdata/dcrdata/issues/214

I accidentally added an extra timestamp class here
https://github.com/dcrdata/dcrdata/commit/0dfee4fce0bd80275bac025a3ddd3d42d918ca2c#diff-8da9f57161fc081f8fd8fed05b5ed3f1R18
which was causing the timeSince fn to get bogus input.

