### PR TITLE
format trailing DCR zeroes on server instead of client

### DIFF
--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -683,7 +683,6 @@ func makeExplorerTxBasic(data dcrjson.TxRawResult, msgTx *wire.MsgTx, params *ch
 		total = total + v.Value
 	}
 	tx.Total = total
-	tx.FormattedTotal = humanize.Commaf(total)
 	tx.Fee, tx.FeeRate = txhelpers.TxFeeRate(msgTx)
 	if ok, _ := stake.IsSSGen(msgTx); ok {
 		validation, version, bits, choices, err := txhelpers.SSGenVoteChoices(msgTx, params)
@@ -713,7 +712,7 @@ func makeExplorerAddressTx(data *dcrjson.SearchRawTransactionsResult) *explorer.
 	for _, v := range data.Vout {
 		total = total + v.Value
 	}
-	tx.FormattedTotal = humanize.Commaf(total)
+	tx.Total = total
 	tx.Time = data.Time
 	t := time.Unix(tx.Time, 0)
 	tx.FormattedTime = t.Format("1/_2/06 15:04:05")

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -4,6 +4,7 @@
 package explorer
 
 import (
+	"fmt"
 	"html/template"
 	"io"
 	"net/http"
@@ -292,6 +293,20 @@ func New(dataSource explorerDataSource, userRealIP bool) *explorerUI {
 		"timezone": func() string {
 			t, _ := time.Now().Zone()
 			return t
+		},
+		"fancyDCR": func(v float64) []string {
+			roundedV := fmt.Sprintf("%.8f", v)
+			trailingZeroes := ""
+			for i := range roundedV {
+				if roundedV[len(roundedV)-1-i] != 48 {
+					break
+				}
+				trailingZeroes += "0"
+			}
+			sliceIndex := len(roundedV) - len(trailingZeroes)
+			roundedV = roundedV[0:sliceIndex]
+			result := append(make([]string, 0, 2), roundedV, trailingZeroes)
+			return result
 		},
 	}
 

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -12,8 +12,8 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/go-chi/chi"
@@ -299,7 +299,7 @@ func New(dataSource explorerDataSource, userRealIP bool) *explorerUI {
 			roundedV := fmt.Sprintf("%.8f", v)
 			oldLength := len(roundedV)
 			roundedV = strings.TrimRight(roundedV, "0")
-			trailingZeros := strings.Repeat("0", oldLength - len(roundedV))
+			trailingZeros := strings.Repeat("0", oldLength-len(roundedV))
 			result := append(make([]string, 0, 2), roundedV, trailingZeros)
 			return result
 		},

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"time"
+	"strings"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/go-chi/chi"
@@ -296,16 +297,10 @@ func New(dataSource explorerDataSource, userRealIP bool) *explorerUI {
 		},
 		"fancyDCR": func(v float64) []string {
 			roundedV := fmt.Sprintf("%.8f", v)
-			trailingZeroes := ""
-			for i := range roundedV {
-				if roundedV[len(roundedV)-1-i] != 48 {
-					break
-				}
-				trailingZeroes += "0"
-			}
-			sliceIndex := len(roundedV) - len(trailingZeroes)
-			roundedV = roundedV[0:sliceIndex]
-			result := append(make([]string, 0, 2), roundedV, trailingZeroes)
+			oldLength := len(roundedV)
+			roundedV = strings.TrimRight(roundedV, "0")
+			trailingZeros := strings.Repeat("0", oldLength - len(roundedV))
+			result := append(make([]string, 0, 2), roundedV, trailingZeros)
 			return result
 		},
 	}

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -25,23 +25,22 @@ type BlockBasic struct {
 
 // TxBasic models data for transactions on the block page
 type TxBasic struct {
-	TxID           string
-	FormattedSize  string
-	FormattedTotal string
-	Total          float64
-	Fee            dcrutil.Amount
-	FeeRate        dcrutil.Amount
-	VoteInfo       *VoteInfo
+	TxID          string
+	FormattedSize string
+	Total         float64
+	Fee           dcrutil.Amount
+	FeeRate       dcrutil.Amount
+	VoteInfo      *VoteInfo
 }
 
 //AddressTx models data for transactions on the address page
 type AddressTx struct {
-	TxID           string
-	FormattedSize  string
-	FormattedTotal string
-	Confirmations  uint64
-	Time           int64
-	FormattedTime  string
+	TxID          string
+	FormattedSize string
+	Total         float64
+	Confirmations uint64
+	Time          int64
+	FormattedTime string
 }
 
 // TxInfo models data needed for display on the tx page

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -27,7 +27,7 @@
                         {{range .Transactions}}
                         <tr>
                             <td><a href="../tx/{{.TxID}}" class="hash">{{.TxID}}</a></td>
-                            <td class="dcr text-right">{{.FormattedTotal}}</td>
+                            <td class="text-right">{{template "fancyDCR" (fancyDCR .Total)}}</td>
                             <td>
                                 {{if eq .Time 0}}
                                     Unconfirmed

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -23,7 +23,7 @@
                 <table>
                     <tr class="h2rem">
                         <td class="pr-2 lh1rem vam text-right xs-w117">TOTAL SENT</td>
-                        <td class="fs28 mono"><span class="dcr mr-1">{{.TotalSent}}</span><span class="fs18 vam">DCR</span></td>
+                        <td class="fs28 mono"><span class="mr-1">{{template "fancyDCR" (fancyDCR .TotalSent)}}</span><span class="fs18 vam">DCR</span></td>
                     </tr>
                 </table>
             </div>
@@ -132,7 +132,7 @@
                     <tr>
                         <td class="text-right pr-2 lh1rem p03rem0">TICKET PRICE</td>
                         <td class="lh1rem">
-                            {{.SBits}}
+                            {{template "fancyDCR" (fancyDCR .SBits)}}
                         </td>
                     </tr>
                     <tr>
@@ -181,7 +181,7 @@
                             {{else}}
                                 -
                             {{end}}</td>
-                            <td class="dcr mono fs15 text-right">{{.FormattedTotal}}</td>
+                            <td class="mono fs15 text-right">{{template "fancyDCR" (fancyDCR .Total)}}</td>
                             <td class="mono fs15">{{.FormattedSize}}</td>
                         </tr>
                         {{end}}
@@ -209,7 +209,7 @@
                                     <a class="hash" href="/explorer/tx/{{.TxID}}">{{.TxID}}</a>
                                 </span>
                             </td>
-                            <td class="text-right dcr mono fs15">{{ .FormattedTotal}}</td>
+                            <td class="text-right dcr mono fs15">{{template "fancyDCR" (fancyDCR .Total)}}</td>
                             <td class="mono fs15 text-right">{{.Fee}}</td>
                             <td class="mono fs15">{{.FormattedSize}}</td>
                         </tr>
@@ -239,7 +239,7 @@
                                     <a class="hash" href="/explorer/tx/{{.TxID}}">{{.TxID}}</a>
                                 </span>
                             </td>
-                            <td class="dcr mono fs15 text-right">{{ .FormattedTotal}}</td>
+                            <td class="mono fs15 text-right">{{template "fancyDCR" (fancyDCR .Total)}}</td>
                             <td class="mono fs15 text-right">{{.Fee}}</td>
                             <td class="mono fs15">{{.FormattedSize}}</td>
                         </tr>
@@ -269,7 +269,7 @@
                                     <a class="hash" href="/explorer/tx/{{.TxID}}">{{.TxID}}</a>
                                 </span>
                             </td>
-                            <td class="dcr mono fs15 text-right">{{.FormattedTotal}}</td>
+                            <td class="mono fs15 text-right">{{template "fancyDCR" (fancyDCR .Total)}}</td>
                             <td class="mono fs15 text-right">{{.Fee}}</td>
                             <td class="mono fs15">{{.FormattedSize}}</td>
                         </tr>

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -144,25 +144,6 @@
         }
         setInterval(updateTime, 10000);
 </script>
-<script type="text/javascript">
-    function styleDCRVal(el) {
-        var text = el.innerText;
-        var chunks = text.split(".");
-        var int = chunks[0];
-        var decimal = (chunks[1] || "").substring(0,8);
-        var numTrailingZeroes = (8 - decimal.length);
-        var zeros = ""
-        if (numTrailingZeroes > 0) {
-            for (var i = 0; i < numTrailingZeroes; i++) {
-                zeros = zeros + "0" + ""
-            }
-        }
-        if (numTrailingZeroes == 8) {
-            el.innerHTML = int + "<span class='decimal'><span class='trailing-zeroes'>." + zeros + "</span></span>"
-        }   else {
-            el.innerHTML = int + ".<span class='decimal'>" + decimal + "<span class='trailing-zeroes'>" + zeros + "</span></span>"
-        }
-    }
-    [].forEach.call(document.getElementsByClassName("dcr"), styleDCRVal)
-</script>
 {{end}}
+
+{{define "fancyDCR"}}{{ index . 0 }}<span class="trailing-zeroes">{{ index . 1 }}</span>{{end}}

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -45,7 +45,7 @@
             <table>
                 <tr class="h2rem">
                     <td class="pr-2 lh1rem vam text-right xs-w91">TOTAL SENT</td>
-                    <td class="fs28 mono nowrap"><span class="dcr mr-1">{{ .FormattedTotal}}</span><span class="fs18 vam">DCR</span></td>
+                    <td class="fs28 mono nowrap"><span class="mr-1">{{template "fancyDCR" (fancyDCR .Total)}}</span><span class="fs18 vam">DCR</span></td>
                 </tr>
                 <tr>
                     <td class="text-right pr-2">TIME</td>
@@ -123,7 +123,8 @@
                             <a class="mono fs13" href="/explorer/block/{{.BlockHeight}}">{{.BlockHeight}}</a></td>
                         {{end}}
                         </td>
-                        <td class="dcr mono fs13 text-right">{{if lt .AmountIn 0.0}} N/A {{else}} {{.FormattedAmount}} {{end}}</td>
+                        <td class="mono fs13 text-right">{{if lt .AmountIn 0.0}} N/A {{else}} {{template "fancyDCR" (fancyDCR .AmountIn)}} {{end}}</td>
+
                     </tr>
                     {{end}}
                 </tbody>
@@ -149,8 +150,8 @@
                         <td>
 				            {{.Type}}
                         </td>
-                        <td class="dcr text-right">
-                            {{.FormattedAmount}}
+                        <td class="text-right">
+                            {{template "fancyDCR" (fancyDCR .Amount)}}
                         </td>
                     </tr>
                     {{end}}


### PR DESCRIPTION
This moves formatting of trailing zeroes in DCR values to the server.
There should be no difference in terms of presentation, other than removed the flash of un-styled content on page load.

This simply uses Sprintf to round to 8 decimals, so this doesn't fully address rounding issues in mentioned in https://github.com/dcrdata/dcrdata/issues/195

I haven't tried optimizing the formatting function, still getting familiar with Go so if you see any obvious optimizations or issues feel free to push a commit/comment.