### PR TITLE
Float amount precision and coin supply formatting

### DIFF
--- a/txhelpers/txhelpers.go
+++ b/txhelpers/txhelpers.go
@@ -610,3 +610,16 @@ func TxFeeRate(msgTx *wire.MsgTx) (dcrutil.Amount, dcrutil.Amount) {
 	}
 	return dcrutil.Amount(amtIn - amtOut), dcrutil.Amount(1000 * (amtIn - amtOut) / int64(msgTx.SerializeSize()))
 }
+
+// TotalVout computes the total value of a slice of dcrjson.Vout
+func TotalVout(vouts []dcrjson.Vout) dcrutil.Amount {
+	var total dcrutil.Amount
+	for _, v := range vouts {
+		a, err := dcrutil.NewAmount(v.Value)
+		if err != nil {
+			continue
+		}
+		total += a
+	}
+	return total
+}

--- a/views/root.tmpl
+++ b/views/root.tmpl
@@ -271,7 +271,7 @@
                     <table class="mb-3 col">
                         <tr class="h2rem">
                             <td class="text-right pr-2 p03rem0 sm-w151 w142 lh1rem">TOTAL SUPPLY</td>
-                            <td class="fs24 mono lh1rem"><span class="dcr">{{.BlockSummary.CoinSupply}}</span>DCR</span></td>
+                            <td class="fs24 mono lh1rem"><span class="dcr">{{.BlockSummary.CoinSupply}}</span></td>
                         </tr>
                         <tr>
                             <td class="text-right pr-2 lh1rem pt-1 pb-1 vam">TICKET PRICE</td>


### PR DESCRIPTION
This fixes floating point precision issues with amount sums.

- Add `txhelpers.TotalVout `to sum each Value for a slice of `Vout`s in `dcrutil.Amount `instead of `float64`.
- Fix `Total` sent precision by summing in `dcrutil.Amount`.

<s>Related, fix coin coin supply display, which was sent to template exec as a string.

- `BlockExplorerExtraInfo.CoinSupply` is now a `int64 `instead of a string.  Previously the string had the `" DCR"` prefix baked in, which messed up the trailing zero styling.
- Add js function `styleAmountAsDCRVal `to handle trailing zero styling similar to `styleDCRVal `but taking an `int64 `with decred atom semantics instead of a `float64 `(coin).  This applies automatically to elements of class `"dcr-amount"`.</s> coin supply fix later