### PR TITLE
Show if tx ouput is spent or unspent

### DIFF
--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -889,12 +889,17 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 	tx.Vin = inputs
 
 	outputs := make([]explorer.Vout, 0, len(txraw.Vout))
-	for _, vout := range txraw.Vout {
+	for i, vout := range txraw.Vout {
+		txout, err := db.client.GetTxOut(txhash, uint32(i), true)
+		if err != nil {
+			log.Warnf("Failed to determine if tx out is spent for ouput %d of tx %s", i, txid)
+		}
 		outputs = append(outputs, explorer.Vout{
 			Addresses:       vout.ScriptPubKey.Addresses,
 			Amount:          vout.Value,
 			FormattedAmount: humanize.Commaf(vout.Value),
 			Type:            vout.ScriptPubKey.Type,
+			Spent:           txout == nil,
 		})
 	}
 	tx.Vout = outputs

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -84,6 +84,7 @@ type Vout struct {
 	Amount          float64
 	FormattedAmount string
 	Type            string
+	Spent           bool
 }
 
 // BlockInfo models data for display on the block page

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -136,6 +136,7 @@
                     <th>Address</th>
                     <th class="text-center">Type</th>
                     <th class="text-center">DCR</th>
+                    <th class="text-center">Spent</th>
                 </thead>
                 <tbody>
                     {{range .Vout}}
@@ -152,6 +153,7 @@
                         <td class="dcr text-right">
                             {{.FormattedAmount}}
                         </td>
+                        <td>{{.Spent}}</td>
                     </tr>
                     {{end}}
                     {{end}}


### PR DESCRIPTION
Should address #110. For an unconfirmed tx, all outputs should show false in the spent column. @gozart you probably have a better idea on how to display this.