### PR TITLE
Change coin supply to int64 and format nicely.

### DIFF
--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -193,7 +193,7 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 	}
 	extrainfo := &apitypes.BlockExplorerExtraInfo{
 		TxLen:            txLen,
-		CoinSupply:       coinSupply.String(),
+		CoinSupply:       int64(coinSupply),
 		NextBlockSubsidy: nbSubsidy,
 	}
 	return blockdata, feeInfoBlock, blockHeaderResults, extrainfo, err

--- a/dcrdataapi/apitypes.go
+++ b/dcrdataapi/apitypes.go
@@ -278,7 +278,7 @@ type BlockExplorerBasic struct {
 type BlockExplorerExtraInfo struct {
 	TxLen            int                            `json:"tx"`
 	FormattedTime    string                         `json:"formatted_time"`
-	CoinSupply       string                         `json:"coin_supply"`
+	CoinSupply       int64                          `json:"coin_supply"`
 	NextBlockSubsidy *dcrjson.GetBlockSubsidyResult `json:"next_block_subsidy"`
 }
 

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -296,12 +296,25 @@ func New(dataSource explorerDataSource, userRealIP bool) *explorerUI {
 			return t
 		},
 		"fancyDCR": func(v float64) []string {
-			roundedV := fmt.Sprintf("%.8f", v)
-			oldLength := len(roundedV)
-			roundedV = strings.TrimRight(roundedV, "0")
-			trailingZeros := strings.Repeat("0", oldLength-len(roundedV))
-			result := append(make([]string, 0, 2), roundedV, trailingZeros)
+			clipped := fmt.Sprintf("%.8f", v)
+			oldLength := len(clipped)
+			clipped = strings.TrimRight(clipped, "0")
+			trailingZeros := strings.Repeat("0", oldLength-len(clipped))
+			result := append(make([]string, 0, 2), clipped, trailingZeros)
 			return result
+		},
+		"amountAsFloatParts": func(v int64) []string {
+			amt := strconv.FormatInt(v, 10)
+			if len(amt) <= 8 {
+				dec := strings.TrimRight(amt, "0")
+				trailingZeros := strings.Repeat("0", len(amt)-len(dec))
+				leadingZeros := strings.Repeat("0", 8-len(amt))
+				return []string{"0", leadingZeros + dec, trailingZeros}
+			}
+			integer := amt[:len(amt)-8]
+			dec := strings.TrimRight(amt[len(amt)-8:], "0")
+			zeros := strings.Repeat("0", 8-len(dec))
+			return []string{integer, dec, zeros}
 		},
 	}
 

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -295,7 +295,7 @@ func New(dataSource explorerDataSource, userRealIP bool) *explorerUI {
 			t, _ := time.Now().Zone()
 			return t
 		},
-		"fancyDCR": func(v float64) []string {
+		"float64SplitZeroSuffix": func(v float64) []string {
 			clipped := fmt.Sprintf("%.8f", v)
 			oldLength := len(clipped)
 			clipped = strings.TrimRight(clipped, "0")

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -27,7 +27,7 @@
                         {{range .Transactions}}
                         <tr>
                             <td><a href="../tx/{{.TxID}}" class="hash">{{.TxID}}</a></td>
-                            <td class="text-right">{{template "fancyDCR" (fancyDCR .Total)}}</td>
+                            <td class="text-right">{{template "floatAndZeroSuffix" (float64SplitZeroSuffix .Total)}}</td>
                             <td>
                                 {{if eq .Time 0}}
                                     Unconfirmed

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -23,7 +23,7 @@
                 <table>
                     <tr class="h2rem">
                         <td class="pr-2 lh1rem vam text-right xs-w117">TOTAL SENT</td>
-                        <td class="fs28 mono"><span class="mr-1">{{template "fancyDCR" (fancyDCR .TotalSent)}}</span><span class="fs18 vam">DCR</span></td>
+                        <td class="fs28 mono"><span class="mr-1">{{template "floatAndZeroSuffix" (float64SplitZeroSuffix .TotalSent)}}</span><span class="fs18 vam">DCR</span></td>
                     </tr>
                 </table>
             </div>
@@ -132,7 +132,7 @@
                     <tr>
                         <td class="text-right pr-2 lh1rem p03rem0">TICKET PRICE</td>
                         <td class="lh1rem">
-                            {{template "fancyDCR" (fancyDCR .SBits)}}
+                            {{template "floatAndZeroSuffix" (float64SplitZeroSuffix .SBits)}}
                         </td>
                     </tr>
                     <tr>
@@ -181,7 +181,7 @@
                             {{else}}
                                 -
                             {{end}}</td>
-                            <td class="mono fs15 text-right">{{template "fancyDCR" (fancyDCR .Total)}}</td>
+                            <td class="mono fs15 text-right">{{template "floatAndZeroSuffix" (float64SplitZeroSuffix .Total)}}</td>
                             <td class="mono fs15">{{.FormattedSize}}</td>
                         </tr>
                         {{end}}
@@ -209,7 +209,7 @@
                                     <a class="hash" href="/explorer/tx/{{.TxID}}">{{.TxID}}</a>
                                 </span>
                             </td>
-                            <td class="text-right dcr mono fs15">{{template "fancyDCR" (fancyDCR .Total)}}</td>
+                            <td class="text-right dcr mono fs15">{{template "floatAndZeroSuffix" (float64SplitZeroSuffix .Total)}}</td>
                             <td class="mono fs15 text-right">{{.Fee}}</td>
                             <td class="mono fs15">{{.FormattedSize}}</td>
                         </tr>
@@ -239,7 +239,7 @@
                                     <a class="hash" href="/explorer/tx/{{.TxID}}">{{.TxID}}</a>
                                 </span>
                             </td>
-                            <td class="mono fs15 text-right">{{template "fancyDCR" (fancyDCR .Total)}}</td>
+                            <td class="mono fs15 text-right">{{template "floatAndZeroSuffix" (float64SplitZeroSuffix .Total)}}</td>
                             <td class="mono fs15 text-right">{{.Fee}}</td>
                             <td class="mono fs15">{{.FormattedSize}}</td>
                         </tr>
@@ -269,7 +269,7 @@
                                     <a class="hash" href="/explorer/tx/{{.TxID}}">{{.TxID}}</a>
                                 </span>
                             </td>
-                            <td class="mono fs15 text-right">{{template "fancyDCR" (fancyDCR .Total)}}</td>
+                            <td class="mono fs15 text-right">{{template "floatAndZeroSuffix" (float64SplitZeroSuffix .Total)}}</td>
                             <td class="mono fs15 text-right">{{.Fee}}</td>
                             <td class="mono fs15">{{.FormattedSize}}</td>
                         </tr>

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -146,5 +146,5 @@
 </script>
 {{end}}
 
-{{define "fancyDCR"}}{{ index . 0 }}<span class="trailing-zeroes">{{ index . 1 }}</span>{{end}}
-{{define "fancyFloatParts"}}{{ index . 0 }}.<span class="decimal">{{ index . 1 }}<span class="trailing-zeroes">{{ index . 2 }}</span></span>{{end}}
+{{define "floatAndZeroSuffix"}}{{ index . 0 }}<span class="trailing-zeroes">{{ index . 1 }}</span>{{end}}
+{{define "floatPartsAndZeroSuffix"}}{{ index . 0 }}.<span class="decimal">{{ index . 1 }}<span class="trailing-zeroes">{{ index . 2 }}</span></span>{{end}}

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -147,3 +147,4 @@
 {{end}}
 
 {{define "fancyDCR"}}{{ index . 0 }}<span class="trailing-zeroes">{{ index . 1 }}</span>{{end}}
+{{define "fancyFloatParts"}}{{ index . 0 }}.<span class="decimal">{{ index . 1 }}<span class="trailing-zeroes">{{ index . 2 }}</span></span>{{end}}

--- a/views/root.tmpl
+++ b/views/root.tmpl
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 
-{{ template "html-head" "Dcrdata Web"}}
+{{ template "html-head" "Decred Block Explorer by dcrdata.org"}}
 
 <body>
         <style>
@@ -271,7 +271,9 @@
                     <table class="mb-3 col">
                         <tr class="h2rem">
                             <td class="text-right pr-2 p03rem0 sm-w151 w142 lh1rem">TOTAL SUPPLY</td>
-                            <td class="fs24 mono lh1rem"><span class="dcr">{{.BlockSummary.CoinSupply}}</span></td>
+                            <td class="fs24 mono lh1rem">
+                                {{template "fancyFloatParts" (amountAsFloatParts .BlockSummary.CoinSupply)}}<span class="pl-1">DCR</span>
+                            </td>
                         </tr>
                         <tr>
                             <td class="text-right pr-2 lh1rem pt-1 pb-1 vam">TICKET PRICE</td>

--- a/views/root.tmpl
+++ b/views/root.tmpl
@@ -272,7 +272,7 @@
                         <tr class="h2rem">
                             <td class="text-right pr-2 p03rem0 sm-w151 w142 lh1rem">TOTAL SUPPLY</td>
                             <td class="fs24 mono lh1rem">
-                                {{template "fancyFloatParts" (amountAsFloatParts .BlockSummary.CoinSupply)}}<span class="pl-1">DCR</span>
+                                {{template "floatPartsAndZeroSuffix" (amountAsFloatParts .BlockSummary.CoinSupply)}}<span class="pl-1">DCR</span>
                             </td>
                         </tr>
                         <tr>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -45,7 +45,7 @@
             <table>
                 <tr class="h2rem">
                     <td class="pr-2 lh1rem vam text-right xs-w91">TOTAL SENT</td>
-                    <td class="fs28 mono nowrap"><span class="mr-1">{{template "fancyDCR" (fancyDCR .Total)}}</span><span class="fs18 vam">DCR</span></td>
+                    <td class="fs28 mono nowrap"><span class="mr-1">{{template "floatAndZeroSuffix" (float64SplitZeroSuffix .Total)}}</span><span class="fs18 vam">DCR</span></td>
                 </tr>
                 <tr>
                     <td class="text-right pr-2">TIME</td>
@@ -123,7 +123,7 @@
                             <a href="/explorer/block/{{.BlockHeight}}">{{.BlockHeight}}</a>
                         {{end}}
                         </td>
-                        <td class="mono fs13 text-right">{{if lt .AmountIn 0.0}} N/A {{else}} {{template "fancyDCR" (fancyDCR .AmountIn)}} {{end}}</td>
+                        <td class="mono fs13 text-right">{{if lt .AmountIn 0.0}} N/A {{else}} {{template "floatAndZeroSuffix" (float64SplitZeroSuffix .AmountIn)}} {{end}}</td>
 
                     </tr>
                     {{end}}
@@ -152,7 +152,7 @@
 				            {{.Type}}
                         </td>
                         <td class="text-right">
-                            {{template "fancyDCR" (fancyDCR .Amount)}}
+                            {{template "floatAndZeroSuffix" (float64SplitZeroSuffix .Amount)}}
                         </td>
                         <td>{{.Spent}}</td>
                     </tr>

--- a/web.go
+++ b/web.go
@@ -93,6 +93,19 @@ func NewWebUI(expSource APIDataSource) *WebUI {
 			p := (float64(i) / 144) * 100
 			return p
 		},
+		"amountAsFloatParts": func(v int64) []string {
+			amt := strconv.FormatInt(v, 10)
+			if len(amt) <= 8 {
+				dec := strings.TrimRight(amt, "0")
+				trailingZeros := strings.Repeat("0", len(amt)-len(dec))
+				leadingZeros := strings.Repeat("0", 8-len(amt))
+				return []string{"0", leadingZeros + dec, trailingZeros}
+			}
+			integer := amt[:len(amt)-8]
+			dec := strings.TrimRight(amt[len(amt)-8:], "0")
+			zeros := strings.Repeat("0", 8-len(dec))
+			return []string{integer, dec, zeros}
+		},
 	}
 	tmpl, err := template.New("home").Funcs(helpers).ParseFiles(fp, efp)
 	if err != nil {


### PR DESCRIPTION
NOTE:  Coin supply is not updated by websocket yet, so this number never changes unless the page reloads

This PR removes `" DCR"` suffix from value passed from go to browser.  Now a JS function expecting just a number that operates on it will not fail.
Add `amountAsFloatParts` function to web and explorer template maps.  It takes an amount as `int64` and returns a `[]string` of: part left of decimal place, right with trailing zeros removed, and trailing zeros.
Add `fancyFloatParts` html template definition that takes the `[]string` from `amountAsFloatParts` and creates a stylized floating point coin value.
Adjust title of root page.