### PR TITLE
handle age formatting via data attributes

### DIFF
--- a/public/js/humanize.js
+++ b/public/js/humanize.js
@@ -22,10 +22,9 @@ var humanize = (function() {
       var precision = (val < 10) ? 1 : 0
       return round(val,precision) + " " + suffix
     },
-    timeSince: function(date) {
-      var seconds = Math.floor(((new Date().getTime()/1000) - date))
+    timeSince: function(unixTime) {
+      var seconds = Math.floor(((new Date().getTime()/1000) - unixTime))
       var interval = Math.floor(seconds / 31536000);
-
       if (interval >= 1) {
         var extra = Math.floor((seconds - interval * 31536000) / 2592000)
         var result = interval + "y"

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -35,13 +35,12 @@
                                     {{.FormattedTime}}
                                 {{end}}
                             </td>
-                            <td class="age">{{if eq .Time 0}}
+                            <td>{{if eq .Time 0}}
                                 N/A
                             {{else}}
-                                {{.Time}}
+                                <span data-age="{{.Time}}"></span>
                             {{end}}
                             </td>
-                            <td class="hidden timestamp">{{.Time}}</td>
                             <td>{{.Confirmations}}</td>
                             <td>{{.FormattedSize}}</td>
                         </tr>

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -94,9 +94,8 @@
                 <table class="">
                     <tr>
                         <td class="text-right lh1rem pr-2">TIME</td>
-                        <td class="lh1rem" style="min-width: 178px ">
-                            <span class="hidden timestamp">{{.BlockTime}}</span>
-                            ({{timezone}}) {{.FormattedTime}} <span class="op60 fs12 nowrap">(<span class="age">{{.BlockTime}}</span> ago)</span>
+                        <td class="lh1rem" style="min-width: 178px;">
+                            ({{timezone}}) {{.FormattedTime}} <span class="op60 fs12 nowrap">(<span data-age="{{.BlockTime}}"></span> ago)</span>
                         </td>
                     </tr>
                     <tr>

--- a/views/explorer.tmpl
+++ b/views/explorer.tmpl
@@ -50,8 +50,7 @@
                             <td>{{.FreshStake}}</td>
                             <td>{{.Revocations}}</td>
                             <td>{{.FormattedBytes}}</td>
-                            <td class="age">{{.BlockTime}}</td>
-                            <td class="hidden timestamp">{{.BlockTime}}</td>
+                            <td data-age="{{.BlockTime}}"></td>
                             <td>{{.FormattedTime}}</td>
                         </tr>
                     {{end}}

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -124,7 +124,6 @@
 {{define "footer"}}
 <footer class="navbar-fixed-bottom">
     <div class="container wrapper text-center">
-        <a class="nav-item" href="www.dcrdata.org" data-turbolinks="false">dcrdata.org</a>
         <a class="nav-item" href="https://github.com/dcrdata/dcrdata" title="dcrdata on GitHub" target="_blank">GitHub</a>
         <a class="nav-item" href="https://github.com/dcrdata/dcrdata#json-rest-api" title="API Endpoints" target="_blank">API</a>
         <a class="nav-item" href="/api/status" title="API Status" target="_blank" data-turbolinks="false">Status</a>

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -133,20 +133,21 @@
 </footer>
 <script data-turbolinks-eval="false">
     var ages, hiddenAges;
-    function findTimeElements() {
-        ages = $(".age");
-        hiddenAges = $(".hidden.timestamp");
+    function setTimeElements() {
+        ages = $('[data-age]');
     }
     function updateAges() {
         $.each(ages, function(i, age) {
-            if (hiddenAges[i].innerText !== "0") {
-                var ageTime = new Date(parseInt(hiddenAges[i].innerText));
-                $(age).text(humanize.timeSince(ageTime))
+            var unixTime = $(age).data('age');
+            if (unixTime > 0) {
+                $(age).text(
+                    humanize.timeSince($(age).data('age'))
+                )
             }
         })
     }
     document.addEventListener("turbolinks:load", function(){
-        findTimeElements()
+        setTimeElements()
         updateAges()
     })
     setInterval(updateAges, 10000);

--- a/views/root.tmpl
+++ b/views/root.tmpl
@@ -62,8 +62,7 @@
                  '<td>' + b.tickets + '</td>' +
                  '<td>' + b.revocations + '</td>' +
                  '<td>' + humanize.bytes(b.size) + '</td>' +
-                 '<td class="age">' + humanize.timeSince(b.time) + '</td>' +
-                 '<td class="hidden timestamp">' + b.time + '</td>' +
+                 '<td data-age=' + b.time + '>' + humanize.timeSince(b.time) + '</td>' +
                  '<td>' + b.formatted_time + '</td>' +
             '</tr>'
             $(newRow).insertBefore(expTableRows.first())
@@ -75,6 +74,7 @@
             $('#blocksdiff').html(b.sdiff.toFixed(4))
             $('#window_block_index').html(newblock.stake.window_block_index)
             $("#pos-window-progess-bar").css({ width: (newblock.stake.window_block_index/144)*100 + "%" })
+            setTimeElements()
         };
 
         ws.registerEvtHandler("newblock", updateBlockData);
@@ -212,8 +212,7 @@
                             <td>{{.FreshStake}}</td>
                             <td>{{.Revocations}}</td>
                             <td>{{formatBytes .Size}}</td>
-                            <td class="age">{{.Time}}</td>
-                            <td class="hidden timestamp">{{.Time}}</td>
+                            <td data-age="{{.Time}}"></td>
                             <td>{{getTime .Time}}</td>
                         </tr>
                     {{end}}

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -53,8 +53,7 @@
                         {{if eq .Time 0}}
                             N/A
                         {{else}}
-                            <span class="hidden timestamp">{{.Time}}</span>
-                            ({{timezone}}) {{.FormattedTime}} <span class="op60 fs12 nowrap">(<span class="age">{{.Time}}</span> ago)</span>
+                            ({{timezone}}) {{.FormattedTime}} <span class="op60 fs12 nowrap">(<span data-age="{{.Time}}"></span> ago)</span>
                         {{end}}
                     </td>
                 </tr>


### PR DESCRIPTION
- Corrects a bug were the wrong type was being passed to timeSince ( requires unixTime, was getting native Date object )
- Simplifies handling of timestamp values by using data attribute, instead of coordinating index of 2 separate arrays of elements.