### PR TITLE
balance cell dimensions of Input/Output tables in tx.tmpl

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -258,8 +258,13 @@ body.darkBG .navbar-fixed-bottom a {
   font-size: 14px;
 }
 .table .address {
-  max-width: 127px;
-  display: inline-block;
+  max-width: 123px;
+}
+.table .outpoint {
+  max-width: 222px;
+}
+.table-fixed {
+  table-layout: fixed;
 }
 
 /*content*/
@@ -337,6 +342,10 @@ body.darkBG .navbar-fixed-bottom a {
   .table {
     margin-bottom: 0;
     width: 100%;
+  }
+  .sm-fullwidth {
+    width: 100%;
+    max-width: 100% !important;
   }
   .sm-w151 {
     width: 151px;

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -101,17 +101,18 @@
     <div class="row">
         <div class="col-md-7 mb-3">
             <h4>Input</h4>
-            <table class="table table-sm striped">
+            <table class="table table-sm table-fixed striped">
                 <thead>
                     <th>Previous Outpoint</th>
                     <th>Addresses</th>
-                    <th class="text-center">Block</th>
-                    <th class="text-center">DCR</th>
+                    <th class="text-center" width="60">Block</th>
+                    <th class="text-center" width="100">DCR</th>
                 </thead>
                 <tbody>
                     {{range .Vin}}
                     <tr>
-                        <td class="break-word">
+                        <td class="break-word mono fs13">
+                            <div class="outpoint">
                             {{if .Coinbase}}
                                 Coinbase: {{ .Coinbase }}
                             {{else if .Stakebase}}
@@ -119,11 +120,12 @@
                             {{else}}
                                 <a href="/explorer/tx/{{.Txid}}">{{.Txid}}:{{.Vout}}</a>
                             {{end}}
+                            </div>
                         </td>
-                        <td><div class="break-word address">
+                        <td><div class="break-word address mono fs13">
                             {{if gt (len .Addresses) 0}}
                                 {{range .Addresses}}
-                                    <a href="/explorer/address/{{.}}">{{.}}</a><br>
+                                    <div><a href="/explorer/address/{{.}}">{{.}}</a></div>
                                 {{end}}
                             {{else}}
                                 N/A
@@ -139,7 +141,6 @@
                         {{end}}
                         </td>
                         <td class="mono fs13 text-right">{{if lt .AmountIn 0.0}} N/A {{else}} {{template "decimalParts" (float64AsDecimalParts .AmountIn false)}} {{end}}</td>
-
                     </tr>
                     {{end}}
                 </tbody>
@@ -147,32 +148,32 @@
         </div>
         <div class="col-md-5 mb-3">
             <h4>Output</h4>
-            <table class="table table-sm striped">
+            <table class="table table-sm table-fixed striped">
                 <thead>
                     <th>Address</th>
-                    <th class="text-center">Type</th>
-                    <th class="text-center">DCR</th>
-                    <th class="text-center">Spent</th>
+                    <th class="text-left">Type</th>
+                    <th class="text-left" width="50">Spent</th>
+                    <th class="text-right" width="100">DCR</th>
                 </thead>
                 <tbody>
-                    {{range .Vout}} 
+                    {{range .Vout}}
                     <tr>
-                        <td class="break-word">
+                        <td class="break-word mono fs13">
                             {{if ne .Amount 0.0}}
                                 {{range .Addresses}}
-                                    <a class="mono address" href="/explorer/address/{{.}}">{{.}}</a><br>
+                                    <div class="address sm-fullwidth"><a href="/explorer/address/{{.}}">{{.}}</a></div>
                                 {{end}}
                             {{else}}
-                                    <a class="mono address">{{.OP_RETURN}}</a>
+                                <a class="address">{{.OP_RETURN}}</a>
                             {{end}}
                         </td>
-                        <td>
-				            {{.Type}}
+                        <td class="fs13 break-word">
+                            {{.Type}}
                         </td>
-                        <td class="text-right">
+                        <td class="text-left fs13">{{.Spent}}</td>
+                        <td class="text-right mono fs13">
                             {{template "decimalParts" (float64AsDecimalParts .Amount false)}}
                         </td>
-                        <td>{{.Spent}}</td>
                     </tr>
                     {{end}}
                 </tbody>


### PR DESCRIPTION
This addresses #244 by tweaking the layout of table cells in tx.tmpl so that the input and output rows are the same height as much as possible over a wide range of screen sizes. Text balancing is tricky business and it's not really possibly to have maintainable/efficient code AND have it look perfect for ALL screen widths. This is an effort to improve over the current state while keeping the CSS simple.

As the old woodcutters saying goes:
"Hew to the line and let the chips fall where they may"

Here's a bunch of screen grabs at various screen widths:

<img width="1131" alt="screen shot 2017-10-24 at 12 11 18 am" src="https://user-images.githubusercontent.com/25571523/31929647-ad3977ea-b851-11e7-9dd6-a2f0df9e37c9.png">
<img width="979" alt="screen shot 2017-10-24 at 12 11 42 am" src="https://user-images.githubusercontent.com/25571523/31929649-ae8feb10-b851-11e7-94ab-efa7c40ce12b.png">
<img width="770" alt="screen shot 2017-10-24 at 12 11 55 am" src="https://user-images.githubusercontent.com/25571523/31929696-d22d83f2-b851-11e7-8bc5-aaa4c8e48509.png">
<img width="761" alt="screen shot 2017-10-24 at 12 12 11 am" src="https://user-images.githubusercontent.com/25571523/31929708-da010874-b851-11e7-9b09-e66621e1e924.png">
<img width="450" alt="screen shot 2017-10-24 at 12 12 21 am" src="https://user-images.githubusercontent.com/25571523/31929714-dcde810c-b851-11e7-8c78-8c1be0f443e5.png">
<img width="398" alt="screen shot 2017-10-24 at 12 28 53 am" src="https://user-images.githubusercontent.com/25571523/31929867-5cf158a6-b852-11e7-8060-3dc06f5d06cb.png">

