### PR TITLE
add maturity progress bar to tx.tmpl

### DIFF
--- a/dcrsqlite/apisource.go
+++ b/dcrsqlite/apisource.go
@@ -926,6 +926,7 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 			tx.Mature = "True"
 		} else {
 			tx.Mature = "False"
+			tx.TicketMaturity = int64(db.params.TicketMaturity)
 		}
 	}
 	if tx.Type == "Vote" {

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -292,9 +292,17 @@ func New(dataSource explorerDataSource, userRealIP bool) *explorerUI {
 	exp.templateFiles["extras"] = filepath.Join("views", "extras.tmpl")
 	exp.templateFiles["address"] = filepath.Join("views", "address.tmpl")
 	exp.templateHelpers = template.FuncMap{
+		"subtract": func(a int64, b int64) int64 {
+			val := a - b
+			return val
+		},
 		"timezone": func() string {
 			t, _ := time.Now().Zone()
 			return t
+		},
+		"percentage": func(a int64, b int64) float64 {
+			p := (float64(a) / float64(b)) * 100
+			return p
 		},
 		"float64AsDecimalParts": func(v float64, useCommas bool) []string {
 			clipped := fmt.Sprintf("%.8f", v)

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -292,6 +292,10 @@ func New(dataSource explorerDataSource, userRealIP bool) *explorerUI {
 	exp.templateFiles["extras"] = filepath.Join("views", "extras.tmpl")
 	exp.templateFiles["address"] = filepath.Join("views", "address.tmpl")
 	exp.templateHelpers = template.FuncMap{
+		"add": func(a int64, b int64) int64 {
+			val := a + b
+			return val
+		},
 		"subtract": func(a int64, b int64) int64 {
 			val := a - b
 			return val

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -57,6 +57,7 @@ type TxInfo struct {
 	FormattedTime   string
 	Mature          string
 	VoteFundsLocked string
+	TicketMaturity  int64
 }
 
 // VoteInfo models data about a SSGen transaction (vote)

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -23,10 +23,10 @@
                 <span class="break-word fs15 w80">{{.TxID}}</span>
                 <a class="fs13 nowrap" href="/api/tx/{{.TxID}}?indent=true" data-turbolinks="false">view raw</a>
             </div>
-            <table class="table-centered-1rem">
+            <table class="table table-centered-1rem">
                 {{if gt .BlockHeight 0}}
                     <tr>
-                        <td class="text-right pr-2 h1rem p03rem0 xs-w91">INCLUDED IN BLOCK</td>
+                        <td width="90" class="text-right pr-2 h1rem p03rem0 xs-w91">INCLUDED IN BLOCK</td>
                         <td>
                              <a href="/explorer/block/{{.BlockHeight}}" class="fs18">{{.BlockHeight}}</a>
                         </td>
@@ -38,11 +38,29 @@
                         {{.Type}}
                     </td>
                 </tr>
-                {{if .Mature}}
+                {{if eq .Mature "True"}}
+                    <td class="text-right pr-2 h1rem p03rem0">MATURE</td><td>{{.Mature}}</td>
+                {{end}}
+                {{if eq .Mature "False"}}
                 <tr>
-                    <td class="text-right pr-2 h1rem p03rem0">MATURE</td>
+                    <td class="text-right pr-2 h1rem p03rem0">MATURITY</td>
                     <td>
-                        {{.Mature}}
+                        <div class="row">
+                            <div class="col-11 col-lg-8 col-sm-12">
+                                <div class="progress" style="max-width: 330px">
+                                    <div
+                                        class="progress-bar"
+                                        role="progressbar"
+                                        style="width: {{percentage (subtract .Confirmations 1) 256}}%; background: #2ed8a3;"
+                                        aria-valuenow="{{.Confirmations}}"
+                                        aria-valuemin="0"
+                                        aria-valuemax="256"
+                                    >
+                                        <span style="color:#383b41" class="nowrap pl-1 pr-1">Immature, spendable in {{ if eq .Confirmations 256 }}next block{{else}}{{subtract 257 .Confirmations}} blocks{{end}}</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </td>
                 </tr>
                 {{end}}

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -51,12 +51,12 @@
                                     <div
                                         class="progress-bar"
                                         role="progressbar"
-                                        style="width: {{percentage (subtract .Confirmations 1) 256}}%; background: #2ed8a3;"
+                                        style="width: {{percentage (subtract .Confirmations 1) .TicketMaturity}}%; background: #2ed8a3;"
                                         aria-valuenow="{{.Confirmations}}"
                                         aria-valuemin="0"
                                         aria-valuemax="256"
                                     >
-                                        <span style="color:#383b41" class="nowrap pl-1 pr-1">Immature, spendable in {{ if eq .Confirmations 256 }}next block{{else}}{{subtract 257 .Confirmations}} blocks{{end}}</span>
+                                        <span style="color:#383b41" class="nowrap pl-1 pr-1">Immature, spendable in {{ if eq .Confirmations .TicketMaturity }}next block{{else}}{{subtract (add .TicketMaturity 1) .Confirmations}} blocks{{end}}</span>
                                     </div>
                                 </div>
                             </div>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -56,7 +56,9 @@
                                         aria-valuemin="0"
                                         aria-valuemax="256"
                                     >
-                                        <span style="color:#383b41" class="nowrap pl-1 pr-1">Immature, spendable in {{ if eq .Confirmations .TicketMaturity }}next block{{else}}{{subtract (add .TicketMaturity 1) .Confirmations}} blocks{{end}}</span>
+                                        <span style="color:#383b41" class="nowrap pl-1 pr-1">
+                                            Immature, {{ if eq .Type "Ticket"}}eligible to vote{{else}}spendable{{end}} in {{ if eq .Confirmations .TicketMaturity }}next block{{else}}{{subtract (add .TicketMaturity 1) .Confirmations}} blocks{{end}}
+                                        </span>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
As described in #247

Some sample scenarios:

<img width="437" alt="screen shot 2017-10-25 at 2 01 45 am" src="https://user-images.githubusercontent.com/25571523/31989921-833947cc-b928-11e7-84ac-f33babf65f39.png">

<img width="599" alt="screen shot 2017-10-25 at 1 51 09 am" src="https://user-images.githubusercontent.com/25571523/31989851-5975968e-b928-11e7-91f0-07329b094795.png">
<img width="1135" alt="screen shot 2017-10-25 at 1 48 19 am" src="https://user-images.githubusercontent.com/25571523/31989866-5f13b74c-b928-11e7-8b52-c80f345232fd.png">
