### PR TITLE
add simple transactions pagination to address.tmpl

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -230,6 +230,7 @@ func (exp *explorerUI) addressPage(w http.ResponseWriter, r *http.Request) {
 		addrData.Limit, addrData.Offset = limitN, offsetAddrOuts
 		addrData.KnownFundingTxns = balance.NumSpent + balance.NumUnspent
 		addrData.Balance = balance
+		addrData.Path = r.URL.Path
 		// still need []*AddressTx filled out and NumUnconfirmed
 
 		// Query database for transaction details
@@ -408,6 +409,10 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 		"percentage": func(a int64, b int64) float64 {
 			p := (float64(a) / float64(b)) * 100
 			return p
+		},
+		"int64Comma": func(v int64) string {
+			t := humanize.Comma(v)
+			return t
 		},
 		"float64AsDecimalParts": func(v float64, useCommas bool) []string {
 			clipped := fmt.Sprintf("%.8f", v)

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -411,8 +411,7 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 			return p
 		},
 		"int64Comma": func(v int64) string {
-			t := humanize.Comma(v)
-			return t
+			return humanize.Comma(v)
 		},
 		"float64AsDecimalParts": func(v float64, useCommas bool) []string {
 			clipped := fmt.Sprintf("%.8f", v)

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -36,7 +36,7 @@ const (
 const (
 	maxExplorerRows          = 2000
 	minExplorerRows          = 20
-	defaultAddressRows int64 = 200
+	defaultAddressRows int64 = 20
 	maxAddressRows     int64 = 1000
 )
 

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -142,6 +142,7 @@ type AddressInfo struct {
 	TotalSent        dcrutil.Amount
 	Unspent          dcrutil.Amount
 	Balance          *AddressBalance
+	Path             string
 }
 
 // AddressBalance represents the number and value of spent and unspent outputs

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -83,7 +83,8 @@ body.darkBG {
   background: #3B3F45;
   color: #fdfdfd;
 }
-body.darkBG a {
+body.darkBG a,
+body.darkBG a:hover {
   color: #94ffca;
 }
 body.darkBG .table thead th {
@@ -96,6 +97,14 @@ body.darkBG .navbar-fixed-bottom {
 body.darkBG .top-nav a,
 body.darkBG .navbar-fixed-bottom a {
   color: #fff;
+}
+body.darkBG .page-link {
+  background-color: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(221, 221, 221, 0);
+}
+body.darkBG .page-item.disabled .page-link {
+  border-color: transparent;
+  background-color: #565656;
 }
 
 /*utils*/
@@ -211,6 +220,12 @@ body.darkBG .navbar-fixed-bottom a {
   color: silver;
   padding: 0 6px;
   position: relative;
+}
+
+/*pagination*/
+.
+#pagesize {
+  flex: 0 60px;
 }
 
 /*table*/

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -49,7 +49,7 @@
                     <h5 class="mr-auto mb-0">Transactions</h5>
                     {{if lt .NumFundingTxns .KnownFundingTxns}}
                     <div div class="d-flex flex-wrap-reverse align-items-center justify-content-end ">
-                        <span class="fs12 nowrap text-right">funding transactions {{int64Comma (add .Offset 1)}} &mdash; {{int64Comma (add (add .Offset 1) .NumFundingTxns)}} of {{int64Comma .KnownFundingTxns}}</span>
+                        <span class="fs12 nowrap text-right">funding transactions {{int64Comma (add .Offset 1)}} &mdash; {{int64Comma (add .Offset .NumFundingTxns)}} of {{int64Comma .KnownFundingTxns}}</span>
                         <nav aria-label="address transactions navigation" data-limit="{{.Limit}}" class="ml-2">
                             <ul class="pagination mb-0 pagination-sm">
                                 <li class="page-item {{if eq .Offset 0}}disabled{{end}}">

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -12,7 +12,7 @@
 
                 <h4>Address</h4>
                 <p class="mono">{{.Address}}</p>
-                <table class="table-centered-1rem">
+                <table class="table-centered-1rem mb-3">
                     {{if .Balance}}
                     {{if not .KnownFundingTxns}}
                     <tr>
@@ -44,13 +44,35 @@
                     </tr>
                     {{end}}
                 </table>
-                <br>
-                <p>
-                {{if lt .NumFundingTxns .KnownFundingTxns}}
-                {{.NumFundingTxns}} of {{.KnownFundingTxns}} funding transactions are tabulated below.
-                {{end}}
-                </p>
-                <h5>Transactions</h5>
+
+                <div class="d-flex flex-wrap align-items-center justify-content-end mb-1">
+                    <h5 class="mr-auto mb-0">Transactions</h5>
+                    {{if lt .NumFundingTxns .KnownFundingTxns}}
+                    <div div class="d-flex flex-wrap-reverse align-items-center justify-content-end ">
+                        <span class="fs12 nowrap text-right">{{int64Comma .Offset}} &mdash; {{int64Comma (add .Offset .NumFundingTxns)}} of {{int64Comma .KnownFundingTxns}} funding transactions.</span>
+                        <nav aria-label="address transactions navigation" data-limit="{{.Limit}}" class="ml-1">
+                            <ul class="pagination mb-0 pagination-sm">
+                                <li class="page-item {{ if lt .Offset .Limit}}disabled{{end}}">
+                                    <a
+                                        class="page-link"
+                                        href="{{.Path}}?n={{.Limit}}&start={{subtract .Offset .Limit}}"
+                                        id="prev"
+                                    >Previous</a>
+                                </li>
+                                <li class="page-item {{if lt (subtract .KnownFundingTxns .Offset) (add .Limit 1)}}disabled{{end}}">
+                                    <a
+                                        class="page-link"
+                                        href="{{.Path}}?n={{.Limit}}&start={{add .Offset .Limit}}"
+                                        id="next">
+                                        Next
+                                    </a>
+                                </li>
+                            </ul>
+                        </nav>
+                    </div>
+                    {{end}}
+                </div>
+
                 <table class="table table-mono-cells table-sm striped">
                     <thead>
                         <th>Transactions ID</th>
@@ -99,6 +121,7 @@
                         {{end}}
                     </tbody>
                 </table>
+
             </div>
         </div>
     </div>

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -132,7 +132,7 @@
                         name="pagesize" 
                         id="pagesize" 
                         class="form-control-sm mb-2 mr-sm-2 mb-sm-0">
-                        <option {{if eq .Limit 10}}selected{{end}} value="10">10</option>
+                        <option {{if eq .Limit 10}}selected{{end}} value="20">20</option>
                         <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
                         <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
                     </select>

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -122,6 +122,7 @@
                     </tbody>
                 </table>
 
+                {{if lt .NumFundingTxns .KnownFundingTxns}}
                 <div 
                     id="pagesize-wrapper" 
                     class="hidden d-flex align-items-center justify-content-end" 
@@ -136,12 +137,14 @@
                         <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
                     </select>
                 </div>      
+                {{end}}
     
             </div>
         </div>
     </div>
 
     {{template "footer"}}
+    {{if lt .NumFundingTxns .KnownFundingTxns}}
     <script>
         $("#pagesize-wrapper").removeClass("hidden")
         var $pagesize = $("#pagesize")
@@ -163,6 +166,7 @@
             $("#next").attr("href", pageLink(pageSize, offset + limit))
         })
     </script>
+    {{end}}
 
 </body>
 </html>

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -52,10 +52,10 @@
                         <span class="fs12 nowrap text-right">{{int64Comma .Offset}} &mdash; {{int64Comma (add .Offset .NumFundingTxns)}} of {{int64Comma .KnownFundingTxns}} funding transactions.</span>
                         <nav aria-label="address transactions navigation" data-limit="{{.Limit}}" class="ml-1">
                             <ul class="pagination mb-0 pagination-sm">
-                                <li class="page-item {{ if lt .Offset .Limit}}disabled{{end}}">
+                                <li class="page-item {{ if eq .Offset 0}}disabled{{end}}">
                                     <a
                                         class="page-link"
-                                        href="{{.Path}}?n={{.Limit}}&start={{subtract .Offset .Limit}}"
+                                        href="{{.Path}}?n={{.Limit}}&start={{if gt (subtract .Offset .Limit) 0}}{{subtract .Offset .Limit}}{{else}}0{{end}}"
                                         id="prev"
                                     >Previous</a>
                                 </li>
@@ -122,11 +122,47 @@
                     </tbody>
                 </table>
 
+                <div 
+                    id="pagesize-wrapper" 
+                    class="hidden d-flex align-items-center justify-content-end" 
+                >
+                    <label class="mb-0 mr-1" for="pagesize">Page size</label>
+                    <select 
+                        name="pagesize" 
+                        id="pagesize" 
+                        class="form-control-sm mb-2 mr-sm-2 mb-sm-0">
+                        <option {{if eq .Limit 10}}selected{{end}} value="10">10</option>
+                        <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
+                        <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
+                    </select>
+                </div>      
+    
             </div>
         </div>
     </div>
 
     {{template "footer"}}
+    <script>
+        $("#pagesize-wrapper").removeClass("hidden")
+        var $pagesize = $("#pagesize")
+        var $prevWrapper = $("#prev").parent()
+        var limit = {{.Limit}}
+        var offset = {{.Offset}}
+        function pageLink(pageSize, start) {
+            return window.location.pathname + '?n='+ pageSize + "&start=" + start
+        }
+        $pagesize.change(function() {
+            var pageSize = parseInt($pagesize.val())
+            var prevStart = Math.max(offset - pageSize, 0)
+            if (prevStart > 0) {
+                if ($prevWrapper.hasClass("disabled")) {
+                    $prevWrapper.removeClass("disabled")
+                }
+            }
+            $("#prev").attr("href", pageLink(pageSize, prevStart))
+            $("#next").attr("href", pageLink(pageSize, offset + limit))
+        })
+    </script>
 
 </body>
 </html>

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -49,8 +49,8 @@
                     <h5 class="mr-auto mb-0">Transactions</h5>
                     {{if lt .NumFundingTxns .KnownFundingTxns}}
                     <div div class="d-flex flex-wrap-reverse align-items-center justify-content-end ">
-                        <span class="fs12 nowrap text-right">{{int64Comma .Offset}} &mdash; {{int64Comma (add .Offset .NumFundingTxns)}} of {{int64Comma .KnownFundingTxns}} funding transactions.</span>
-                        <nav aria-label="address transactions navigation" data-limit="{{.Limit}}" class="ml-1">
+                        <span class="fs12 nowrap text-right">funding transactions {{int64Comma (add .Offset 1)}} &mdash; {{int64Comma (add (add .Offset 1) .NumFundingTxns)}} of {{int64Comma .KnownFundingTxns}}</span>
+                        <nav aria-label="address transactions navigation" data-limit="{{.Limit}}" class="ml-2">
                             <ul class="pagination mb-0 pagination-sm">
                                 <li class="page-item {{if eq .Offset 0}}disabled{{end}}">
                                     <a
@@ -123,22 +123,22 @@
                 </table>
 
                 {{if lt .NumFundingTxns .KnownFundingTxns}}
-                <div 
-                    id="pagesize-wrapper" 
-                    class="hidden d-flex align-items-center justify-content-end" 
+                <div
+                    id="pagesize-wrapper"
+                    class="hidden d-flex align-items-center justify-content-end"
                 >
                     <label class="mb-0 mr-1" for="pagesize">Page size</label>
-                    <select 
-                        name="pagesize" 
-                        id="pagesize" 
+                    <select
+                        name="pagesize"
+                        id="pagesize"
                         class="form-control-sm mb-2 mr-sm-2 mb-sm-0">
                         <option {{if eq .Limit 10}}selected{{end}} value="20">20</option>
                         <option {{if eq .Limit 100}}selected{{end}} value="100">100</option>
                         <option {{if eq .Limit 1000}}selected{{end}} value="1000">1000</option>
                     </select>
-                </div>      
+                </div>
                 {{end}}
-    
+
             </div>
         </div>
     </div>
@@ -147,23 +147,12 @@
     {{if lt .NumFundingTxns .KnownFundingTxns}}
     <script>
         $("#pagesize-wrapper").removeClass("hidden")
-        var $pagesize = $("#pagesize")
-        var $prevWrapper = $("#prev").parent()
-        var limit = {{.Limit}}
-        var offset = {{.Offset}}
-        function pageLink(pageSize, start) {
-            return window.location.pathname + '?n='+ pageSize + "&start=" + start
-        }
-        $pagesize.change(function() {
-            var pageSize = parseInt($pagesize.val())
-            var prevStart = Math.max(offset - pageSize, 0)
-            if (prevStart > 0) {
-                if ($prevWrapper.hasClass("disabled")) {
-                    $prevWrapper.removeClass("disabled")
-                }
-            }
-            $("#prev").attr("href", pageLink(pageSize, prevStart))
-            $("#next").attr("href", pageLink(pageSize, offset + limit))
+        $("#pagesize").change(function(ev) {
+            Turbolinks.visit(
+                window.location.pathname
+                + '?n='+ parseInt($(ev.currentTarget).val())
+                + "&start=" + {{.Offset}}
+            )
         })
     </script>
     {{end}}

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -52,7 +52,7 @@
                         <span class="fs12 nowrap text-right">{{int64Comma .Offset}} &mdash; {{int64Comma (add .Offset .NumFundingTxns)}} of {{int64Comma .KnownFundingTxns}} funding transactions.</span>
                         <nav aria-label="address transactions navigation" data-limit="{{.Limit}}" class="ml-1">
                             <ul class="pagination mb-0 pagination-sm">
-                                <li class="page-item {{ if eq .Offset 0}}disabled{{end}}">
+                                <li class="page-item {{if eq .Offset 0}}disabled{{end}}">
                                     <a
                                         class="page-link"
                                         href="{{.Path}}?n={{.Limit}}&start={{if gt (subtract .Offset .Limit) 0}}{{subtract .Offset .Limit}}{{else}}0{{end}}"

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -28,7 +28,6 @@
     <script src="/js/humanize.js"></script>
     <script src="/js/turbolinks.js"></script>
     <script src="/js/jquery.min.js"></script>
-    <!-- <script src="/js/Chart.min.js"></script> -->
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>


### PR DESCRIPTION
This adds some basic pagination UI to address.tmpl 
issue #262

<img width="515" alt="screen shot 2017-11-05 at 1 11 47 pm" src="https://user-images.githubusercontent.com/25571523/32419192-1ca45482-c22b-11e7-9578-272b4382fe8b.png">
<img width="516" alt="screen shot 2017-11-05 at 1 11 41 pm" src="https://user-images.githubusercontent.com/25571523/32419193-22009954-c22b-11e7-918f-548cbe497608.png">
<img width="500" alt="screen shot 2017-11-05 at 12 48 32 pm" src="https://user-images.githubusercontent.com/25571523/32419194-24edbbe2-c22b-11e7-9355-663bb5cf7bec.png">
<img width="1147" alt="screen shot 2017-11-05 at 12 48 09 pm" src="https://user-images.githubusercontent.com/25571523/32419196-2ffd4804-c22b-11e7-978b-6d6155747c54.png">
<img width="512" alt="screen shot 2017-11-05 at 1 08 13 pm" src="https://user-images.githubusercontent.com/25571523/32419199-371d8a54-c22b-11e7-90df-1ceeaa20c40a.png">
