### PR TITLE
Do not rebuild indexes so easiliy.

### DIFF
--- a/db/dcrpg/postgresql-tuning.conf
+++ b/db/dcrpg/postgresql-tuning.conf
@@ -13,8 +13,10 @@ min_wal_size = 2GB
 checkpoint_completion_target = 0.8
 default_statistics_target = 200
 
+# OK for general use on a stable system. Insert with alacrity.
+synchronous_commit = off
+
 # Large import/insert only
 autovacuum = off
 fsync = off # but synchronous_commit is probably enough
-synchronous_commit = off
 full_page_writes = off

--- a/main.go
+++ b/main.go
@@ -188,11 +188,11 @@ func mainCore() error {
 		return fmt.Errorf("Node is still syncing. Node height = %d, "+
 			"DB height = %d", height, heightDB)
 	}
-	if blocksBehind > 500 {
+	if blocksBehind > 7500 {
 		log.Infof("Setting PSQL sync to rebuild address table after large "+
 			"import (%d blocks).", blocksBehind)
 		updateAllAddresses = true
-		if blocksBehind > 4000 {
+		if blocksBehind > 40000 {
 			log.Infof("Setting PSQL sync to drop indexes prior to bulk data "+
 				"import (%d blocks).", blocksBehind)
 			newPGIndexes = true


### PR DESCRIPTION
The threshold of blocks behind tip to rebuild indexes is way to low.

Also recommend `synchronous_commit` for general use.