### PR TITLE
Added decode tx page and view raw link

### DIFF
--- a/apirouter.go
+++ b/apirouter.go
@@ -115,20 +115,23 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 	})
 
 	mux.Route("/tx", func(r chi.Router) {
-		r.Route("/{txid}", func(rd chi.Router) {
-			rd.Use(TransactionHashCtx)
-			rd.Get("/", app.getTransaction)
-			rd.Route("/out", func(ro chi.Router) {
-				ro.Get("/", app.getTransactionOutputs)
-				ro.With(TransactionIOIndexCtx).Get("/{txinoutindex}", app.getTransactionOutput)
+		r.Route("/", func(rt chi.Router) {
+			rt.Route("/{txid}", func(rd chi.Router) {
+				rd.Use(TransactionHashCtx)
+				rd.Get("/", app.getTransaction)
+				rd.Route("/out", func(ro chi.Router) {
+					ro.Get("/", app.getTransactionOutputs)
+					ro.With(TransactionIOIndexCtx).Get("/{txinoutindex}", app.getTransactionOutput)
+				})
+				rd.Route("/in", func(ri chi.Router) {
+					ri.Get("/", app.getTransactionInputs)
+					ri.With(TransactionIOIndexCtx).Get("/{txinoutindex}", app.getTransactionInput)
+				})
+				rd.Get("/vinfo", app.getTxVoteInfo)
 			})
-			rd.Route("/in", func(ri chi.Router) {
-				ri.Get("/", app.getTransactionInputs)
-				ri.With(TransactionIOIndexCtx).Get("/{txinoutindex}", app.getTransactionInput)
-			})
-			rd.Get("/vinfo", app.getTxVoteInfo)
-			rd.Get("/raw", app.getTransactionHex)
 		})
+		r.With(TransactionHashCtx).Get("/hex/{txid}", app.getTransactionHex)
+		r.With(TransactionHashCtx).Get("/decoded/{txid}", app.getDecodedTx)
 	})
 
 	mux.Route("/address", func(r chi.Router) {

--- a/apirouter.go
+++ b/apirouter.go
@@ -127,6 +127,7 @@ func newAPIRouter(app *appContext, userRealIP bool) apiMux {
 				ri.With(TransactionIOIndexCtx).Get("/{txinoutindex}", app.getTransactionInput)
 			})
 			rd.Get("/vinfo", app.getTxVoteInfo)
+			rd.Get("/raw", app.getTransactionHex)
 		})
 	})
 

--- a/apiroutes.go
+++ b/apiroutes.go
@@ -24,6 +24,7 @@ type APIDataSource interface {
 	GetBlockVerbose(idx int, verboseTx bool) *dcrjson.GetBlockVerboseResult
 	GetBlockVerboseByHash(hash string, verboseTx bool) *dcrjson.GetBlockVerboseResult
 	GetRawTransaction(txid string) *apitypes.Tx
+	GetTransactionHex(txid string) *apitypes.TxRaw
 	GetRawTransactionWithPrevOutAddresses(txid string) (*apitypes.Tx, [][]string)
 	GetVoteInfo(txid string) (*apitypes.VoteInfo, error)
 	GetVoteVersionInfo(ver uint32) (*dcrjson.GetVoteInfoResult, error)
@@ -468,6 +469,23 @@ func (c *appContext) getTransaction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tx := c.BlockData.GetRawTransaction(txid)
+	if tx == nil {
+		apiLog.Errorf("Unable to get transaction %s", txid)
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+
+	writeJSON(w, tx, c.getIndentQuery(r))
+}
+
+func (c *appContext) getTransactionHex(w http.ResponseWriter, r *http.Request) {
+	txid := getTxIDCtx(r)
+	if txid == "" {
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+
+	tx := c.BlockData.GetTransactionHex(txid)
 	if tx == nil {
 		apiLog.Errorf("Unable to get transaction %s", txid)
 		http.Error(w, http.StatusText(422), 422)

--- a/apiroutes.go
+++ b/apiroutes.go
@@ -24,7 +24,8 @@ type APIDataSource interface {
 	GetBlockVerbose(idx int, verboseTx bool) *dcrjson.GetBlockVerboseResult
 	GetBlockVerboseByHash(hash string, verboseTx bool) *dcrjson.GetBlockVerboseResult
 	GetRawTransaction(txid string) *apitypes.Tx
-	GetTransactionHex(txid string) *apitypes.TxRaw
+	GetTransactionHex(txid string) string
+	GetTrimmedTransaction(txid string) *apitypes.TrimmedTx
 	GetRawTransactionWithPrevOutAddresses(txid string) (*apitypes.Tx, [][]string)
 	GetVoteInfo(txid string) (*apitypes.VoteInfo, error)
 	GetVoteVersionInfo(ver uint32) (*dcrjson.GetVoteInfoResult, error)
@@ -485,7 +486,19 @@ func (c *appContext) getTransactionHex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tx := c.BlockData.GetTransactionHex(txid)
+	hex := c.BlockData.GetTransactionHex(txid)
+
+	fmt.Fprintf(w, hex)
+}
+
+func (c *appContext) getDecodedTx(w http.ResponseWriter, r *http.Request) {
+	txid := getTxIDCtx(r)
+	if txid == "" {
+		http.Error(w, http.StatusText(422), 422)
+		return
+	}
+
+	tx := c.BlockData.GetTrimmedTransaction(txid)
 	if tx == nil {
 		apiLog.Errorf("Unable to get transaction %s", txid)
 		http.Error(w, http.StatusText(422), 422)

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -6,6 +6,7 @@ package dcrsqlite
 import (
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -340,18 +341,18 @@ func (db *wiredDB) DecodeRawTransaction(txhex string) *dcrjson.TxRawResult {
 	return tx
 }
 
-func (db *wiredDB) SendRawTransaction(txhex string) string {
+func (db *wiredDB) SendRawTransaction(txhex string) (string, error) {
 	msg := txhelpers.MsgTxFromHex(txhex)
 	if msg == nil {
 		log.Errorf("SendRawTransaction failed: could not decode hex")
-		return ""
+		return "", errors.New("Could not decode hex")
 	}
 	hash, err := db.client.SendRawTransaction(msg, true)
 	if err != nil {
 		log.Errorf("SendRawTransaction failed: %v", err)
-		return ""
+		return "", err
 	}
-	return hash.String()
+	return hash.String(), err
 }
 
 func (db *wiredDB) GetTrimmedTransaction(txid string) *apitypes.TrimmedTx {

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -321,6 +321,29 @@ func (db *wiredDB) GetRawTransaction(txid string) *apitypes.Tx {
 	return tx
 }
 
+func (db *wiredDB) GetTransactionHex(txid string) *apitypes.TxRaw {
+	_, hex := db.getRawTransaction(txid)
+	return &apitypes.TxRaw{
+		TxID: txid,
+		Hex:  hex,
+	}
+}
+
+func (db *wiredDB) DecodeRawTransaction(hex string) *dcrjson.TxRawResult {
+	msgTx := txhelpers.MsgTxFromHex(hex)
+	bytes, err := msgTx.Bytes()
+	if err != nil {
+		log.Errorf("DecodeRawTransaction failed: %v", err)
+		return nil
+	}
+	tx, err := db.client.DecodeRawTransaction(bytes)
+	if err != nil {
+		log.Errorf("DecodeRawTransaction failed: %v", err)
+		return nil
+	}
+	return tx
+}
+
 func (db *wiredDB) getRawTransaction(txid string) (*apitypes.Tx, string) {
 	tx := new(apitypes.Tx)
 

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -327,18 +327,18 @@ func (db *wiredDB) GetTransactionHex(txid string) string {
 	return hex
 }
 
-func (db *wiredDB) DecodeRawTransaction(txhex string) *dcrjson.TxRawResult {
+func (db *wiredDB) DecodeRawTransaction(txhex string) (*dcrjson.TxRawResult, error) {
 	bytes, err := hex.DecodeString(txhex)
 	if err != nil {
 		log.Errorf("DecodeRawTransaction failed: %v", err)
-		return nil
+		return nil, err
 	}
 	tx, err := db.client.DecodeRawTransaction(bytes)
 	if err != nil {
 		log.Errorf("DecodeRawTransaction failed: %v", err)
-		return nil
+		return nil, err
 	}
-	return tx
+	return tx, nil
 }
 
 func (db *wiredDB) SendRawTransaction(txhex string) (string, error) {

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -329,9 +329,8 @@ func (db *wiredDB) GetTransactionHex(txid string) *apitypes.TxRaw {
 	}
 }
 
-func (db *wiredDB) DecodeRawTransaction(hex string) *dcrjson.TxRawResult {
-	msgTx := txhelpers.MsgTxFromHex(hex)
-	bytes, err := msgTx.Bytes()
+func (db *wiredDB) DecodeRawTransaction(txhex string) *dcrjson.TxRawResult {
+	bytes, err := hex.DecodeString(txhex)
 	if err != nil {
 		log.Errorf("DecodeRawTransaction failed: %v", err)
 		return nil

--- a/dcrdataapi/apitypes.go
+++ b/dcrdataapi/apitypes.go
@@ -6,7 +6,6 @@ package dcrdataapi
 import (
 	"github.com/dcrdata/dcrdata/txhelpers"
 	"github.com/decred/dcrd/dcrjson"
-	"github.com/decred/dcrd/dcrutil"
 )
 
 // much of the time, dcrdata will be using the types in dcrjson, but others are
@@ -44,14 +43,10 @@ type TxShort struct {
 	Vout     []Vout        `json:"vout"`
 }
 
-// ExplorerTxData packs data for display on the explorer tx page
-type ExplorerTxData struct {
-	*Tx
-	VinAddrs [][]string
-	Type     string
-	Fee      dcrutil.Amount
-	FeeRate  dcrutil.Amount
-	*VoteInfo
+// TxRaw warps the hex of a tx
+type TxRaw struct {
+	TxID string `json:"txid"`
+	Hex  string `json:"hex"`
 }
 
 // VoteInfo models data about a SSGen transaction (vote)

--- a/dcrdataapi/apitypes.go
+++ b/dcrdataapi/apitypes.go
@@ -43,10 +43,15 @@ type TxShort struct {
 	Vout     []Vout        `json:"vout"`
 }
 
-// TxRaw warps the hex of a tx
-type TxRaw struct {
-	TxID string `json:"txid"`
-	Hex  string `json:"hex"`
+// TrimmedTx models data to resemble to result of the decoderawtransaction
+// call
+type TrimmedTx struct {
+	TxID     string        `json:"txid"`
+	Version  int32         `json:"version"`
+	Locktime uint32        `json:"locktime"`
+	Expiry   uint32        `json:"expiry"`
+	Vin      []dcrjson.Vin `json:"vin"`
+	Vout     []Vout        `json:"vout"`
 }
 
 // VoteInfo models data about a SSGen transaction (vote)

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/decred/dcrd/dcrjson"
+
 	"github.com/dcrdata/dcrdata/blockdata"
 	"github.com/dcrdata/dcrdata/db/dbtypes"
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -37,6 +39,7 @@ const (
 	blockTemplateIndex
 	txTemplateIndex
 	addressTemplateIndex
+	decodeTxTemplateIndex
 )
 
 const (
@@ -55,6 +58,7 @@ type explorerDataSourceLite interface {
 	GetBlockHash(idx int64) (string, error)
 	GetExplorerTx(txid string) *TxInfo
 	GetExplorerAddress(address string, count, offset int64) *AddressInfo
+	DecodeRawTransaction(hex string) *dcrjson.TxRawResult
 	GetHeight() int
 }
 
@@ -135,9 +139,39 @@ func (exp *explorerUI) rootWebsocket(w http.ResponseWriter, r *http.Request) {
 				exp.wsHub.HubRelay <- sigPingAndUserCount
 			}
 		}()
-
+		go func() {
+			for {
+				msg := &WebSocketMessage{}
+				websocket.JSON.Receive(ws, &msg)
+				if msg.EventId == "decodetx" {
+					log.Debug("Recieved decodetx signal for hex", msg.Messsage)
+					tx := exp.blockData.DecodeRawTransaction(msg.Messsage)
+					if tx == nil {
+						log.Debugf("Could not decode raw tx")
+						continue
+					}
+					buff := new(bytes.Buffer)
+					enc := json.NewEncoder(buff)
+					enc.SetIndent("", "\t")
+					enc.Encode(tx)
+					webData := WebSocketMessage{
+						EventId:  "decodedtx",
+						Messsage: buff.String(),
+					}
+					err := websocket.JSON.Send(ws, webData)
+					if err != nil {
+						log.Debugf("Failed to encode WebSocketMessage decodedtx: %v", err)
+						// If the send failed, the client is probably gone, so close
+						// the connection and quit.
+						return
+					}
+					log.Debugf("Sent decoded tx")
+				}
+			}
+		}()
 	loop:
 		for {
+
 			// Wait for signal from the hub to update
 			select {
 			case sig, ok := <-updateSig:
@@ -364,6 +398,18 @@ func (exp *explorerUI) addressPage(w http.ResponseWriter, r *http.Request) {
 	io.WriteString(w, str)
 }
 
+func (exp *explorerUI) decodeTxPage(w http.ResponseWriter, r *http.Request) {
+	str, err := templateExecToString(exp.templates[decodeTxTemplateIndex], "rawtx", nil)
+	if err != nil {
+		log.Errorf("Template execute failure: %v", err)
+		http.Redirect(w, r, "/error", http.StatusTemporaryRedirect)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html")
+	w.WriteHeader(http.StatusOK)
+	io.WriteString(w, str)
+}
+
 // search implements a primitive search algorithm by checking if the value in
 // question is a block index, block hash, address hash or transaction hash and
 // redirects to the appropriate page or displays an error
@@ -453,10 +499,19 @@ func (exp *explorerUI) reloadTemplates() error {
 		return err
 	}
 
+	decodeTxTemplate, err := template.New("rawTx").Funcs(exp.templateHelpers).ParseFiles(
+		exp.templateFiles["rawTx"],
+		exp.templateFiles["extras"],
+	)
+	if err != nil {
+		return err
+	}
+
 	exp.templates[rootTemplateIndex] = explorerTemplate
 	exp.templates[blockTemplateIndex] = blockTemplate
 	exp.templates[txTemplateIndex] = txTemplate
 	exp.templates[addressTemplateIndex] = addressTemplate
+	exp.templates[decodeTxTemplateIndex] = decodeTxTemplate
 
 	return nil
 }
@@ -510,6 +565,7 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 	exp.templateFiles["tx"] = filepath.Join("views", "tx.tmpl")
 	exp.templateFiles["extras"] = filepath.Join("views", "extras.tmpl")
 	exp.templateFiles["address"] = filepath.Join("views", "address.tmpl")
+	exp.templateFiles["rawtx"] = filepath.Join("views", "rawtx.tmpl")
 	exp.templateHelpers = template.FuncMap{
 		"add": func(a int64, b int64) int64 {
 			val := a + b
@@ -611,6 +667,7 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 		log.Errorf("Unable to create new html template: %v", err)
 	}
 	exp.templates = append(exp.templates, txTemplate)
+
 	addrTemplate, err := template.New("address").Funcs(exp.templateHelpers).ParseFiles(
 		exp.templateFiles["address"],
 		exp.templateFiles["extras"],
@@ -619,6 +676,15 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 		log.Errorf("Unable to create new html template: %v", err)
 	}
 	exp.templates = append(exp.templates, addrTemplate)
+
+	decodeTxTemplate, err := template.New("rawtx").Funcs(exp.templateHelpers).ParseFiles(
+		exp.templateFiles["rawtx"],
+		exp.templateFiles["extras"],
+	)
+	if err != nil {
+		log.Errorf("Unable to create new html template: %v", err)
+	}
+	exp.templates = append(exp.templates, decodeTxTemplate)
 
 	exp.addRoutes()
 
@@ -684,6 +750,10 @@ func (exp *explorerUI) addRoutes() {
 			rd.Get("/", exp.addressPage)
 			rd.Get("/ws", exp.rootWebsocket)
 		})
+	})
+	exp.Mux.Route("/decodetx", func(r chi.Router) {
+		r.Get("/", exp.decodeTxPage)
+		r.Get("/ws", exp.rootWebsocket)
 	})
 
 	exp.Mux.With(searchPathCtx).Get("/search/{search}", exp.search)

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -59,7 +59,7 @@ type explorerDataSourceLite interface {
 	GetExplorerTx(txid string) *TxInfo
 	GetExplorerAddress(address string, count, offset int64) *AddressInfo
 	DecodeRawTransaction(txhex string) *dcrjson.TxRawResult
-	SendRawTransaction(txhex string) string
+	SendRawTransaction(txhex string) (string, error)
 	GetHeight() int
 }
 
@@ -163,9 +163,9 @@ func (exp *explorerUI) rootWebsocket(w http.ResponseWriter, r *http.Request) {
 				case "sendtx":
 					webData.EventId = "senttx"
 					log.Debug("Recieved sendtx signal for hex: ", msg.Messsage)
-					txid := exp.blockData.SendRawTransaction(msg.Messsage)
-					if txid == "" {
-						webData.Messsage = fmt.Sprintf("Error: Could not send hex %s\nTry decoding it first to see if it's valid", msg.Messsage)
+					txid, err := exp.blockData.SendRawTransaction(msg.Messsage)
+					if err != nil {
+						webData.Messsage = fmt.Sprintf("Error: %v", err)
 					} else {
 						webData.Messsage = fmt.Sprintf("Transaction sent: %s", txid)
 					}

--- a/explorer/websocket.go
+++ b/explorer/websocket.go
@@ -8,8 +8,8 @@ import (
 // WebSocketMessage represents the JSON object used to send and received typed
 // messages to the web client.
 type WebSocketMessage struct {
-	EventId  string `json:"event"`
-	Messsage string `json:"message"`
+	EventId string `json:"event"`
+	Message string `json:"message"`
 }
 
 // Event type field for an SSE event

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -115,6 +115,9 @@ body.darkBG .json-block {
   position: relative;
   top: -33px;
 }
+.clickable {
+  cursor: pointer;
+}
 .hidden {
   display: none;
 }
@@ -458,3 +461,20 @@ body.darkBG .json-block {
   background: rgba(128, 128, 128, 0.07);
   padding: 1px 5px;
 }
+
+/*bootstrap overrides*/
+.btn-primary {
+  background-color: #2970ff;
+  border-color: #2970ff;
+}
+.btn-success {
+  background-color: #2ed6a1;
+  border-color:  #2ed6a1;
+}
+.btn-success:hover {
+  background: #3fc39a;
+  border-color: #3fc39a;
+}
+
+
+

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -15,7 +15,7 @@
                     {{else}}
                         <span class="op60 fs12">best block</span>
                     {{end}}
-                    <a class="fs12" href="/api/block/{{.Height}}/verbose?indent=true" data-turbolinks="false">view raw</a>
+                    <a class="fs12" href="/api/block/{{.Height}}/verbose?indent=true" data-turbolinks="false">view decoded</a>
                 </h4>
             </div>
             <div class="col-md-5 col-sm-6 d-flex">

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -166,12 +166,13 @@
             //ws.send("pong", "copy")
         });
         ws.registerEvtHandler("decodedtx", function(evt) {
-            console.log("Got message: ", evt)
+            console.log("Got message: ", evt);
+            $("#decode_header").text("Decoded tx");
             $("#decoded_tx").text(evt);
         })
         ws.registerEvtHandler("senttx", function(evt) {
-            console.log("Got message: ", evt)
-            $("#decode_header").text("Sent tx")
+            console.log("Got message: ", evt);
+            $("#decode_header").text("Sent tx");
             $("#decoded_tx").text(evt);
         })
         var updateBlockData = function (event) {

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -162,8 +162,12 @@
 
         ws.registerEvtHandler("ping", function(evt) {
             console.log("ping. users online: ", evt)
-            ws.send("pong", "copy")
+            //ws.send("pong", "copy")
         });
+        ws.registerEvtHandler("decodedtx", function(evt) {
+            console.log("Got message: ", evt)
+            $("#decoded_tx").text(evt);
+        })
         var updateBlockData = function (event) {
             console.log("Received newblock message", event);
             var newBlock = JSON.parse(event);
@@ -269,6 +273,14 @@
         updateAges()
     })
     setInterval(updateAges, 10000);
+    document.getElementById('rawtx').onkeypress = function(e){
+        if (!e) e = window.event;
+        var keyCode = e.keyCode || e.which;
+        if (keyCode == '13'){
+            ws.send("decodetx", this.value)
+            return false;
+        }
+    }
 </script>
 <script>
     $('.scriptDataStar').on('click',function(){

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -169,6 +169,11 @@
             console.log("Got message: ", evt)
             $("#decoded_tx").text(evt);
         })
+        ws.registerEvtHandler("senttx", function(evt) {
+            console.log("Got message: ", evt)
+            $("#decode_header").text("Sent tx")
+            $("#decoded_tx").text(evt);
+        })
         var updateBlockData = function (event) {
             console.log("Received newblock message", event);
             var newBlock = JSON.parse(event);
@@ -250,6 +255,7 @@
     <div class="container wrapper text-center">
         <a class="nav-item" href="https://github.com/dcrdata/dcrdata" title="dcrdata on GitHub" target="_blank">GitHub</a>
         <a class="nav-item" href="https://github.com/dcrdata/dcrdata#json-rest-api" title="API Endpoints" target="_blank">API</a>
+        <a class="nav-item" href="/explorer/decodetx" title="Decode or send a raw transaction">Decode Tx</a>
         <a class="nav-item" href="/api/status" title="API Status" target="_blank" data-turbolinks="false">Status</a>
         <span data-turbolinks-permanent class="nav-item hidden" id="connection">Connecting to WebSocket...<div></div></span>
     </div>

--- a/views/rawtx.tmpl
+++ b/views/rawtx.tmpl
@@ -16,20 +16,25 @@
                         placeholder="Enter the transation hex here"
                     /></textarea>
                 </form>
-                <h4 class="mb-2">Decoded tx</h4>
-<pre
-    id="decoded_tx"
-    class="json-block mono"
->
+                <h4 class="mb-2" id="decode_header">Decoded tx</h4><button id="send_tx">Send Tx</button>
+            <pre
+                id="decoded_tx"
+                class="json-block mono"
+            >
 
-    Press Enter or click here to decode
+                Press Enter or click here to decode
 
-</pre>
+            </pre>
         </div>
         <script>
+            $("#send_tx").on("click", function() {
+                var msg = $("#rawtx").val();
+                    if (msg !== ""){
+                        ws.send("sendtx", msg);
+                    }
+            })
             setTimeout(function(){
-                $("#rawtx")
-                    .keypress( function(e){
+                $("#rawtx").keypress( function(e){
                         if (!e) e = window.event;
                         var keyCode = e.keyCode || e.which;
                         if (keyCode == '13'){

--- a/views/rawtx.tmpl
+++ b/views/rawtx.tmpl
@@ -1,0 +1,25 @@
+{{define "rawtx"}}
+<!DOCTYPE html>
+<html lang="en">
+    {{template "html-head" printf "Decred Transaction %.20s..." .TxID}}
+    <body>
+        {{template "navbar"}}
+        <div class="container">
+                <h4 class="mb-2">Decode a Decred transaction</h4>
+                <form>
+                    <input
+                    autofocus
+                    type="text"
+                    name="rawtx"
+                    id="rawtx"
+                    placeholder="Enter the transation hex here"
+                    />
+                </form>
+                <h4 class="mb-2">Decoded tx</h4>
+                <pre id="decoded_tx">
+                </pre>
+        </div>
+        {{template "footer"}}
+    </body>
+</html>
+{{end}}

--- a/views/rawtx.tmpl
+++ b/views/rawtx.tmpl
@@ -5,52 +5,51 @@
     <body>
         {{template "navbar"}}
         <div class="container">
-                <h4 class="mb-2">Decode a Decred transaction</h4>
-                <form>
-                    <textarea
-                        autofocus
-                        rows="6"
-                        class="col"
-                        name="rawtx"
-                        id="rawtx"
-                        placeholder="Enter the transation hex here"
-                    /></textarea>
-                </form>
-                <h4 class="mb-2" id="decode_header">Decoded tx</h4><button id="send_tx">Send Tx</button>
+            <h4 class="mb-2">Decode a Decred transaction</h4>
+            <form>
+                <textarea
+                    autofocus
+                    rows="6"
+                    class="col"
+                    name="rawtx"
+                    id="rawtx"
+                    placeholder="Enter the transation hex here"
+                /></textarea>
+                <button id="decode_tx" class="button btn btn-primary mr-1">Decode Tx</button>
+                <button id="send_tx" class="button btn btn-success">Send Tx</button>
+            </form>
+            <h4 class="mb-2" id="decode_header">Decoded tx</h4>
             <pre
                 id="decoded_tx"
-                class="json-block mono"
+                class="json-block mono pt-3 pr-3 pb-3 pl-3"
             >
-
-                Press Enter or click here to decode
-
             </pre>
         </div>
         <script>
             $("#send_tx").on("click", function() {
                 var msg = $("#rawtx").val();
-                    if (msg !== ""){
-                        ws.send("sendtx", msg);
-                    }
+                if (msg !== ""){
+                    ws.send("sendtx", msg);
+                }
+            })
+            $("#decode_tx").on("click", function(){
+                var msg = $("#rawtx").val();
+                if (msg !== ""){
+                    ws.send("decodetx", msg);
+                }
             })
             setTimeout(function(){
                 $("#rawtx").keypress( function(e){
-                        if (!e) e = window.event;
-                        var keyCode = e.keyCode || e.which;
-                        if (keyCode == '13'){
-                            if (this.value !== "") {
-                                ws.send("decodetx", this.value);
-                            }
-                            return false;
+                    if (!e) e = window.event;
+                    var keyCode = e.keyCode || e.which;
+                    if (keyCode == '13'){
+                        if (this.value !== "") {
+                            ws.send("decodetx", this.value);
                         }
-                    })
-                    .focus()
-                $("#decoded_tx").on("click", function(){
-                    var msg = $("#rawtx").val();
-                    if (msg !== ""){
-                        ws.send("decodetx", msg);
+                        return false;
                     }
                 })
+                .focus()
             }, 14)
         </script>
         {{template "footer"}}

--- a/views/rawtx.tmpl
+++ b/views/rawtx.tmpl
@@ -15,8 +15,8 @@
                     id="rawtx"
                     placeholder="Enter the transation hex here"
                 /></textarea>
-                <button id="decode_tx" class="button btn btn-primary mr-1">Decode Tx</button>
-                <button id="send_tx" class="button btn btn-success">Send Tx</button>
+                <button type="button" id="decode_tx" class="button btn btn-primary mr-1">Decode Tx</button>
+                <button type="button" id="send_tx" class="button btn btn-success">Send Tx</button>
             </form>
             <h4 class="mb-2" id="decode_header">Decoded tx</h4>
             <pre

--- a/views/rawtx.tmpl
+++ b/views/rawtx.tmpl
@@ -33,13 +33,18 @@
                         if (!e) e = window.event;
                         var keyCode = e.keyCode || e.which;
                         if (keyCode == '13'){
-                            ws.send("decodetx", this.value)
+                            if (this.value !== "") {
+                                ws.send("decodetx", this.value);
+                            }
                             return false;
                         }
                     })
                     .focus()
                 $("#decoded_tx").on("click", function(){
-                    ws.send("decodetx", $("#rawtx").val())
+                    var msg = $("#rawtx").val();
+                    if (msg !== ""){
+                        ws.send("decodetx", msg);
+                    }
                 })
             }, 14)
         </script>

--- a/views/rawtx.tmpl
+++ b/views/rawtx.tmpl
@@ -1,7 +1,7 @@
 {{define "rawtx"}}
 <!DOCTYPE html>
 <html lang="en">
-    {{template "html-head" printf "Decred Transaction %.20s..." .TxID}}
+    {{template "html-head" printf "Decode Raw Recred Transaction"}}
     <body>
         {{template "navbar"}}
         <div class="container">

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -21,7 +21,8 @@
             </h4>
             <div class="lh1rem mb-1">
                 <span class="break-word fs15 w80">{{.TxID}}</span>
-                <a class="fs13 nowrap" href="/api/tx/{{.TxID}}?indent=true" data-turbolinks="false">view raw</a>
+                <a class="fs13 nowrap" href="/api/tx/{{.TxID}}?indent=true" data-turbolinks="false">view decoded</a>
+                <a class="fs13 nowrap" href="/api/tx/{{.TxID}}/raw" data-turbolinks="false">view raw</a>
             </div>
             <table class="table table-centered-1rem">
                 {{if gt .BlockHeight 0}}

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -21,9 +21,9 @@
             </h4>
             <div class="lh1rem mb-1">
                 <span class="break-word fs15 w80 mr-1">{{.TxID}}</span>
-                <a class="fs13 nowrap" href="/api/tx/{{.TxID}}?indent=true" data-turbolinks="false">api</a>
+                <a class="fs13 nowrap" href="/api/tx/decoded/{{.TxID}}?indent=true" data-turbolinks="false">view decoded</a>
                 <span class="sep"></span>
-                <a class="fs13 nowrap" href="/api/tx/{{.TxID}}/raw" data-turbolinks="false">hex</a>
+                <a class="fs13 nowrap" href="/api/tx/hex/{{.TxID}}" data-turbolinks="false">view hex</a>
             </div>
             <table class="table table-centered-1rem">
                 {{if gt .BlockHeight 0}}

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -21,9 +21,11 @@
             </h4>
             <div class="lh1rem mb-1">
                 <span class="break-word fs15 w80 mr-1">{{.TxID}}</span>
-                <a class="fs13 nowrap" href="/api/tx/decoded/{{.TxID}}?indent=true" data-turbolinks="false">view decoded</a>
-                <span class="sep"></span>
-                <a class="fs13 nowrap" href="/api/tx/hex/{{.TxID}}" data-turbolinks="false">view hex</a>
+                <span class="nowrap">
+                    <a class="fs13 nowrap" href="/api/tx/decoded/{{.TxID}}?indent=true" data-turbolinks="false">view decoded</a>
+                    <span class="sep"></span>
+                    <a class="fs13 nowrap" href="/api/tx/hex/{{.TxID}}" data-turbolinks="false">view hex</a>
+                </span>
             </div>
             <table class="table table-centered-1rem">
                 {{if gt .BlockHeight 0}}


### PR DESCRIPTION
For issues #190 and #136 . The rpc api has no "getrawblock" function so that can't be added, but the view raw link works as intended now, showing the txid and hex while the view decoded link shows the json output. The decode tx pages works as intended as well but doesn't look so good for now.
