### PR TITLE
explorer websocket: check error on websocket.JSON.Receive, fix client ping

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -145,7 +145,7 @@ func (exp *explorerUI) rootWebsocket(w http.ResponseWriter, r *http.Request) {
 			}
 		}()
 
-		// Start listening for websocket messages from clinet with raw
+		// Start listening for websocket messages from client with raw
 		// transaction bytes (hex encoded) to decode or broadcast.
 		go func() {
 			for {

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -196,7 +196,8 @@ func (exp *explorerUI) rootWebsocket(w http.ResponseWriter, r *http.Request) {
 						webData.Message = fmt.Sprintf("Transaction sent: %s", txid)
 					}
 				case "ping":
-					log.Tracef("We've been pinged: %v", msg.Message)
+					log.Tracef("We've been pinged: %.40s...", msg.Message)
+					continue
 				default:
 					log.Warnf("Unrecognized event ID: %v", msg.EventId)
 					continue

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -138,19 +138,30 @@ func (exp *explorerUI) rootWebsocket(w http.ResponseWriter, r *http.Request) {
 		ticker := time.NewTicker(pingInterval)
 		defer ticker.Stop()
 
+		// Periodically ping clients over websocket connection
 		go func() {
 			for range ticker.C {
 				exp.wsHub.HubRelay <- sigPingAndUserCount
 			}
 		}()
+
+		// Start listening for websocket messages from clinet with raw
+		// transaction bytes (hex encoded) to decode or broadcast.
 		go func() {
 			for {
+				// Wait to receive a message on the websocket
 				msg := &WebSocketMessage{}
-				websocket.JSON.Receive(ws, &msg)
+				ws.SetReadDeadline(time.Now().Add(wsReadTimeout))
+				if err := websocket.JSON.Receive(ws, &msg); err != nil {
+					log.Warnf("websocket client receive error: %v", err)
+					return
+				}
+
+				// handle received message according to event ID
 				var webData WebSocketMessage
 				switch msg.EventId {
 				case "decodetx":
-					webData.EventId = "decodedtx"
+					webData.EventId = msg.EventId + "Resp"
 					if len(msg.Message) > requestLimit {
 						log.Debug("Request size over limit")
 						webData.Message = "Request too large"
@@ -171,7 +182,7 @@ func (exp *explorerUI) rootWebsocket(w http.ResponseWriter, r *http.Request) {
 						webData.Message = fmt.Sprintf("Error: %v", err)
 					}
 				case "sendtx":
-					webData.EventId = "senttx"
+					webData.EventId = msg.EventId + "Resp"
 					if len(msg.Message) > requestLimit {
 						log.Debugf("Request size over limit")
 						webData.Message = "Request too large"
@@ -184,19 +195,26 @@ func (exp *explorerUI) rootWebsocket(w http.ResponseWriter, r *http.Request) {
 					} else {
 						webData.Message = fmt.Sprintf("Transaction sent: %s", txid)
 					}
-				}
-				if webData.EventId == "" {
+				case "ping":
+					log.Tracef("We've been pinged: %v", msg.Message)
+				default:
+					log.Warnf("Unrecognized event ID: %v", msg.EventId)
 					continue
 				}
-				err := websocket.JSON.Send(ws, webData)
-				if err != nil {
-					log.Debugf("Failed to encode WebSocketMessage decodedtx: %v", err)
+
+				// send the response back on the websocket
+				ws.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
+				if err := websocket.JSON.Send(ws, webData); err != nil {
+					log.Debugf("Failed to encode WebSocketMessage %s: %v",
+						webData.EventId, err)
 					// If the send failed, the client is probably gone, so close
 					// the connection and quit.
 					return
 				}
 			}
 		}()
+
+		// Ping and block update loop (send only)
 	loop:
 		for {
 			// Wait for signal from the hub to update
@@ -217,7 +235,6 @@ func (exp *explorerUI) rootWebsocket(w http.ResponseWriter, r *http.Request) {
 				}
 
 				log.Tracef("signaling client: %p", &updateSig)
-				ws.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
 
 				// Write block data to websocket client
 				exp.NewBlockDataMtx.RLock()
@@ -235,6 +252,7 @@ func (exp *explorerUI) rootWebsocket(w http.ResponseWriter, r *http.Request) {
 					webData.Message = strconv.Itoa(exp.wsHub.NumClients())
 				}
 
+				ws.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
 				err := websocket.JSON.Send(ws, webData)
 				exp.NewBlockDataMtx.RUnlock()
 				if err != nil {

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -544,8 +544,8 @@ func (exp *explorerUI) reloadTemplates() error {
 		return err
 	}
 
-	decodeTxTemplate, err := template.New("rawTx").Funcs(exp.templateHelpers).ParseFiles(
-		exp.templateFiles["rawTx"],
+	decodeTxTemplate, err := template.New("rawtx").Funcs(exp.templateHelpers).ParseFiles(
+		exp.templateFiles["rawtx"],
 		exp.templateFiles["extras"],
 	)
 	if err != nil {

--- a/explorer/websocket.go
+++ b/explorer/websocket.go
@@ -36,6 +36,7 @@ type hubSpoke chan hubSignal
 
 const (
 	wsWriteTimeout           = 10 * time.Second
+	wsReadTimeout            = 12 * time.Second
 	pingInterval             = 12 * time.Second
 	sigNewBlock    hubSignal = iota
 	sigPingAndUserCount

--- a/public/js/messagesocket.js
+++ b/public/js/messagesocket.js
@@ -41,7 +41,7 @@ var MessageSocket = function(uri) {
   }
 
   // send a message back to the server
-  this.send = function(eventID, message) {
+  var send = function(eventID, message) {
     var payload = JSON.stringify({
       event: eventID,
       message: message
@@ -50,6 +50,7 @@ var MessageSocket = function(uri) {
     ws.send(payload);
     return this;
   };
+  this.send = send;
 
   // unmarshall message, and forward the message to registered handlers
   ws.onmessage = function(evt) {
@@ -83,7 +84,7 @@ var MessageSocket = function(uri) {
 
   // Start ping pong
   var pinger = setInterval(function () {
-    ws.send("ping", 'Hi. I am a client!');
-  }, 1000);
+    send("ping","sup");
+  }, 7000);
 
 };

--- a/version.go
+++ b/version.go
@@ -10,8 +10,8 @@ type version struct {
 
 var ver = version{
 	Major: 1,
-	Minor: 0,
-	Patch: 1,
+	Minor: 1,
+	Patch: 0,
 	Label: ""}
 
 // CommitHash may be set on the build command line:

--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -165,12 +165,12 @@
             console.log("ping. users online: ", evt)
             //ws.send("pong", "copy")
         });
-        ws.registerEvtHandler("decodedtx", function(evt) {
+        ws.registerEvtHandler("decodetxResp", function(evt) {
             console.log("Got message: ", evt);
             $("#decode_header").text("Decoded tx");
             $("#decoded_tx").text(evt);
         })
-        ws.registerEvtHandler("senttx", function(evt) {
+        ws.registerEvtHandler("sendtxResp", function(evt) {
             console.log("Got message: ", evt);
             $("#decode_header").text("Sent tx");
             $("#decoded_tx").text(evt);

--- a/views/rawtx.tmpl
+++ b/views/rawtx.tmpl
@@ -1,7 +1,7 @@
 {{define "rawtx"}}
 <!DOCTYPE html>
 <html lang="en">
-    {{template "html-head" printf "Decode Raw Recred Transaction"}}
+    {{template "html-head" printf "Decode Raw Decred Transaction"}}
     <body>
         {{template "navbar"}}
         <div class="container">

--- a/views/rawtx.tmpl
+++ b/views/rawtx.tmpl
@@ -5,7 +5,7 @@
     <body>
         {{template "navbar"}}
         <div class="container">
-            <h4 class="mb-2">Decode a Decred transaction</h4>
+            <h4 class="mb-2">Decred transaction to decode or broadcast</h4>
             <form>
                 <textarea
                     autofocus
@@ -13,12 +13,12 @@
                     class="col"
                     name="rawtx"
                     id="rawtx"
-                    placeholder="Enter the transation hex here"
+                    placeholder="Enter the full transation (hexadecimal encoded) here"
                 /></textarea>
-                <button type="button" id="decode_tx" class="button btn btn-primary mr-1">Decode Tx</button>
-                <button type="button" id="send_tx" class="button btn btn-success">Send Tx</button>
+                <button type="button" id="decode_tx" class="button btn btn-primary mr-1">Decode</button>
+                <button type="button" id="send_tx" class="button btn btn-success">Broadcast</button>
             </form>
-            <h4 class="mb-2" id="decode_header">Decoded tx</h4>
+            <h4 class="mb-2" id="decode_header">Decoded transaction</h4>
             <pre
                 id="decoded_tx"
                 class="json-block mono pt-3 pr-3 pb-3 pl-3"
@@ -27,12 +27,16 @@
         </div>
         <script>
             $("#send_tx").on("click", function() {
+                $("#decoded_tx").text('');
+                $('#decoded_tx').fadeTo(0, 0.3, function() { $(this).fadeTo(500, 1.0); });
                 var msg = $("#rawtx").val();
                 if (msg !== ""){
                     ws.send("sendtx", msg);
                 }
             })
             $("#decode_tx").on("click", function(){
+                $("#decoded_tx").text('');
+                $('#decoded_tx').fadeTo(100, 0.3, function() { $(this).fadeTo(500, 1.0); });
                 var msg = $("#rawtx").val();
                 if (msg !== ""){
                     ws.send("decodetx", msg);
@@ -43,6 +47,8 @@
                     if (!e) e = window.event;
                     var keyCode = e.keyCode || e.which;
                     if (keyCode == '13'){
+                        $("#decoded_tx").text('');
+                        $('#decoded_tx').fadeTo(100, 0.3, function() { $(this).fadeTo(500, 1.0); });
                         if (this.value !== "") {
                             ws.send("decodetx", this.value);
                         }


### PR DESCRIPTION
Addresses issue https://github.com/dcrdata/dcrdata/issues/285.

- Set server's response event IDs to the incoming message's event ID + "Resp".
- Client side ping (in JS) was not sending a JSON response, which the server's websocket handler did not appreciate.  Fix this by using the same send function (i.e. `function(eventID, message)`) as the other messages.
- Recognize the "ping" event ID in server's websocket read loop.
- Change client side ping from every 1 sec to 7 seconds.
- Create websocket read timeout, set to 12 seconds. Write is 10 seconds.
- Set both read and write deadlines where appropriate.
- Docs.
- Fix reloading of explorer templates with SIGUSR1.
- Add pulse effect to rawtx result box to ack click/keypress.