### PR TITLE
move address TOTAL UNSPENT to top right

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -319,16 +319,16 @@ body.darkBG .json-block {
   font-size: 13px;
 }
 
-/* Typography    */
+/*Typography*/
 .fs14-decimal .dot,
 .fs14-decimal .decimal,
 .fs14-decimal .unit {
     font-size: 14px
 }
-.fs18-decimal .dot,
-.fs18-decimal .decimal,
-.fs18-decimal .unit {
-    font-size: 18px
+.fs16-decimal .dot,
+.fs16-decimal .decimal,
+.fs16-decimal .unit {
+    font-size: 16px
 }
 .sep {
   position: relative;
@@ -397,7 +397,7 @@ body.darkBG .json-block {
 }
 @media only screen and (max-width: 576px)  {
   .xs-w91 {
-    width: 91px;
+    width: 91px !important;
   }
   .xs-w117 {
     width: 117px;

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -8,47 +8,57 @@
     {{template "navbar"}}
     <div class="container">
         <div class="row">
-            <div class="col-md-12">
-
+            <div class="col-md-8 col-sm-6">
                 <h4>Address</h4>
-                <p class="mono">{{.Address}}</p>
-                <table class="table-centered-1rem mb-3">
+                <div class="mono">{{.Address}}</div>
+                <table class="table-centered-1rem">
                     {{if .Balance}}
                     {{if not .KnownFundingTxns}}
                     <tr>
                         <td class="text-right pr-2 h1rem p03rem0">The {{.NumFundingTxns}} most recent transactions are tabulated below.</td>
                     </tr>
                     {{end}}
-                    <tr>
-                        <td class="text-right pr-2 h1rem p03rem0">TRANSACTIONS</td>
-                        <td>{{add .Balance.NumSpent .Balance.NumUnspent}}</td>
-                    </tr>
                     <!-- <tr>
                         <td class="text-right pr-2 h1rem p03rem0">UNCONFIRMED</td>
                         <td>{{.NumUnconfirmed}}</td>
                     </tr> -->
+                    {{end}}
+                </table>
+            </div>
+            <div class="col-md-4 col-sm-6 d-flex pb-3">
+                <table>
+                    {{if .Balance}}
+                    <tr class="h2rem">
+                        <td class="pr-2 lh1rem vam text-right xs-w91">TOTAL UNSPENT</td>
+                        <td class="fs28 mono nowrap fs16-decimal d-flex align-items-center justify-content-end">
+                            {{template "decimalParts" (amountAsDecimalParts .Balance.TotalUnspent true)}}<span class="pl-1 unit">DCR</span>
+                        </td>
+                    </tr>
                     <tr>
-                        <td class="text-right pr-2 h1rem p03rem0">RECEIVED</td>
-                        <td>{{with $received := add .Balance.TotalSpent .Balance.TotalUnspent}}
-                            {{template "decimalParts" (amountAsDecimalParts $received true)}}<span class="unit"> DCR</span>
+                        <td class="text-right pr-2">RECEIVED</td>
+                        <td class="mono nowrap text-right">
+                            {{with $received := add .Balance.TotalSpent .Balance.TotalUnspent}}
+                            {{template "decimalParts" (amountAsDecimalParts $received true)}}<span class="pl-1 unit">DCR</span>
                             {{end}}
                         </td>
                     </tr>
                     <tr>
-                        <td class="text-right pr-2 h1rem p03rem0">SPENT</td>
-                        <td>{{template "decimalParts" (amountAsDecimalParts .Balance.TotalSpent true)}}<span class="unit"> DCR</span></td>
-                    </tr>
-                    <tr>
-                        <td class="text-right pr-2 h1rem p03rem0">UNSPENT</td>
-                        <td>{{template "decimalParts" (amountAsDecimalParts .Balance.TotalUnspent true)}}<span class="unit"> DCR</span></td>
+                        <td class="text-right pr-2">SPENT</td>
+                        <td class="mono nowrap text-right">
+                            {{template "decimalParts" (amountAsDecimalParts .Balance.TotalSpent true)}}<span class="pl-1 unit">DCR</span>
+                        </td>
                     </tr>
                     {{end}}
                 </table>
+            </div>
+        </div>
 
+        <div class="row">
+            <div class="col">
                 <div class="d-flex flex-wrap align-items-center justify-content-end mb-1">
                     <h5 class="mr-auto mb-0">Transactions</h5>
                     {{if lt .NumFundingTxns .KnownFundingTxns}}
-                    <div div class="d-flex flex-wrap-reverse align-items-center justify-content-end ">
+                    <div div class="d-flex flex-wrap-reverse align-items-center justify-content-end">
                         <span class="fs12 nowrap text-right">funding transactions {{int64Comma (add .Offset 1)}} &mdash; {{int64Comma (add .Offset .NumFundingTxns)}} of {{int64Comma .KnownFundingTxns}}</span>
                         <nav aria-label="address transactions navigation" data-limit="{{.Limit}}" class="ml-2">
                             <ul class="pagination mb-0 pagination-sm">
@@ -70,6 +80,8 @@
                             </ul>
                         </nav>
                     </div>
+                    {{else}}
+                    <span class="fs12 nowrap text-right">{{int64Comma .KnownFundingTxns}} funding transaction{{if gt 1 .KnownFundingTxns}}s{{end}}</span>
                     {{end}}
                 </div>
 

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -22,7 +22,7 @@
                 <table>
                     <tr class="h2rem">
                         <td class="pr-2 lh1rem vam text-right xs-w117 w120">TOTAL SENT</td>
-                        <td class="fs28 mono fs18-decimal d-flex align-items-center">{{template "decimalParts" (float64AsDecimalParts .TotalSent false)}}<span class="pl-1 unit">DCR</span></td>
+                        <td class="fs28 mono fs16-decimal d-flex align-items-center">{{template "decimalParts" (float64AsDecimalParts .TotalSent false)}}<span class="pl-1 unit">DCR</span></td>
                     </tr>
                 </table>
             </div>

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -85,7 +85,7 @@
             <table>
                 <tr class="h2rem">
                     <td class="pr-2 lh1rem vam text-right xs-w91">TOTAL SENT</td>
-                    <td class="fs28 mono nowrap fs18-decimal d-flex align-items-center">{{template "decimalParts" (float64AsDecimalParts .Total false)}}<span class="pl-1 unit">DCR</span></td>
+                    <td class="fs28 mono nowrap fs16-decimal d-flex align-items-center">{{template "decimalParts" (float64AsDecimalParts .Total false)}}<span class="pl-1 unit">DCR</span></td>
                 </tr>
                 <tr>
                     <td class="text-right pr-2">TIME</td>


### PR DESCRIPTION
This makes is so that the DCR sum value is consistently located in the top right across the tx, block and address views.

<img width="1134" alt="screen shot 2017-11-24 at 1 53 07 am" src="https://user-images.githubusercontent.com/25571523/33205308-51438278-d0bb-11e7-9111-b123acfbed7e.png">

<img width="637" alt="screen shot 2017-11-24 at 1 53 19 am" src="https://user-images.githubusercontent.com/25571523/33205321-5c361970-d0bb-11e7-95ea-2001a484cee7.png">

<img width="396" alt="screen shot 2017-11-24 at 1 53 31 am" src="https://user-images.githubusercontent.com/25571523/33205330-677c5452-d0bb-11e7-9537-495d12dec2db.png">
