### PR TITLE
explorer: make int64Comma generic

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -629,8 +629,27 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 			p := (float64(a) / float64(b)) * 100
 			return p
 		},
-		"int64Comma": func(v int64) string {
-			return humanize.Comma(v)
+		"intComma": func(v interface{}) string {
+			var vi64 int64
+			switch vt := v.(type) {
+			case int64:
+				vi64 = vt
+			case int32:
+				vi64 = int64(vt)
+			case uint32:
+				vi64 = int64(vt)
+			case uint64:
+				vi64 = int64(vt)
+			case int:
+				vi64 = int64(vt)
+			case int16:
+				vi64 = int64(vt)
+			case uint16:
+				vi64 = int64(vt)
+			default:
+				return ""
+			}
+			return humanize.Comma(vi64)
 		},
 		"float64AsDecimalParts": func(v float64, useCommas bool) []string {
 			clipped := fmt.Sprintf("%.8f", v)

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"math"
 	"net/http"
 	"os"
 	"os/signal"
@@ -612,6 +613,28 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 	exp.templateFiles["extras"] = filepath.Join("views", "extras.tmpl")
 	exp.templateFiles["address"] = filepath.Join("views", "address.tmpl")
 	exp.templateFiles["rawtx"] = filepath.Join("views", "rawtx.tmpl")
+
+	toInt64 := func(v interface{}) int64 {
+		switch vt := v.(type) {
+		case int64:
+			return vt
+		case int32:
+			return int64(vt)
+		case uint32:
+			return int64(vt)
+		case uint64:
+			return int64(vt)
+		case int:
+			return int64(vt)
+		case int16:
+			return int64(vt)
+		case uint16:
+			return int64(vt)
+		default:
+			return math.MinInt64
+		}
+	}
+
 	exp.templateHelpers = template.FuncMap{
 		"add": func(a int64, b int64) int64 {
 			val := a + b
@@ -629,27 +652,12 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 			p := (float64(a) / float64(b)) * 100
 			return p
 		},
+		"int64": toInt64,
 		"intComma": func(v interface{}) string {
-			var vi64 int64
-			switch vt := v.(type) {
-			case int64:
-				vi64 = vt
-			case int32:
-				vi64 = int64(vt)
-			case uint32:
-				vi64 = int64(vt)
-			case uint64:
-				vi64 = int64(vt)
-			case int:
-				vi64 = int64(vt)
-			case int16:
-				vi64 = int64(vt)
-			case uint16:
-				vi64 = int64(vt)
-			default:
-				return ""
-			}
-			return humanize.Comma(vi64)
+			return humanize.Comma(toInt64(v))
+		},
+		"int64Comma": func(v int64) string {
+			return humanize.Comma(v)
 		},
 		"float64AsDecimalParts": func(v float64, useCommas bool) []string {
 			clipped := fmt.Sprintf("%.8f", v)

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -59,7 +59,7 @@
                     <h5 class="mr-auto mb-0">Transactions</h5>
                     {{if lt .NumFundingTxns .KnownFundingTxns}}
                     <div div class="d-flex flex-wrap-reverse align-items-center justify-content-end">
-                        <span class="fs12 nowrap text-right">funding transactions {{int64Comma (add .Offset 1)}} &mdash; {{int64Comma (add .Offset .NumFundingTxns)}} of {{int64Comma .KnownFundingTxns}}</span>
+                        <span class="fs12 nowrap text-right">funding transactions {{intComma (add .Offset 1)}} &mdash; {{intComma (add .Offset .NumFundingTxns)}} of {{intComma .KnownFundingTxns}}</span>
                         <nav aria-label="address transactions navigation" data-limit="{{.Limit}}" class="ml-2">
                             <ul class="pagination mb-0 pagination-sm">
                                 <li class="page-item {{if eq .Offset 0}}disabled{{end}}">
@@ -81,7 +81,7 @@
                         </nav>
                     </div>
                     {{else}}
-                    <span class="fs12 nowrap text-right">{{int64Comma .KnownFundingTxns}} funding transaction{{if gt 1 .KnownFundingTxns}}s{{end}}</span>
+                    <span class="fs12 nowrap text-right">{{intComma .KnownFundingTxns}} funding transaction{{if gt 1 .KnownFundingTxns}}s{{end}}</span>
                     {{end}}
                 </div>
 

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -99,7 +99,7 @@
                     </tr>
                     <tr>
                         <td class="text-right pr-2 lh1rem xs-w117">SIZE</td>
-                        <td class="mono">{{.FormattedBytes}}</td>
+                        <td class="mono" title="{{intComma .Size}} Bytes">{{.FormattedBytes}}</td>
                     </tr>
                     <tr>
                         <td class="text-right pr-2 lh1rem p03rem0 xs-w117"><a href="#votes">VOTES</a></td>


### PR DESCRIPTION
Change the template function `int64Comma(v int64)` into `intComma(v interface{})` using a type switch to accept all integer types.

Use `intComma` to give the block size text a hover text for the comma-formatted bytes, as show below:

![image](https://user-images.githubusercontent.com/9373513/33216595-50b5adf8-d0e9-11e7-8bed-a701f18b8291.png)

(the mouse pointer isn't shown, but it's hovering over the size text)