### PR TITLE
Stake tables: tickets, votes, misses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ vendor/
 *.orig
 *.db
 *.db-journal
+dcrdata.sqlt.db*
 rebuilddb.conf
 rebuilddb2.conf
 cmd/rebuilddb/rebuilddb

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -210,6 +210,12 @@
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
+  name = "github.com/oleiade/lane"
+  packages = ["."]
+  revision = "28f7c3f09254f12b51e620fa4db136ba58804762"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/rs/cors"
   packages = ["."]
   revision = "eabcc6af4bbe5ad3a949d36450326a2b0b9894b8"
@@ -251,6 +257,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "836268df262b429d87f8bb52c809321058a4ba640a07658efd7194fbc1508c69"
+  inputs-digest = "4c7eec3b639d27568fbb3e9f647cb6d0f9dc41c4118242735c46b00ba72b2108"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -257,6 +257,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4c7eec3b639d27568fbb3e9f647cb6d0f9dc41c4118242735c46b00ba72b2108"
+  inputs-digest = "752ef1af27fee71e6a40332aaeed13bcda0400f30dd4ca65beaa1383559a80ea"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -389,6 +389,8 @@ Yes, please! See the CONTRIBUTING.md file for details, but here's the gist of it
 Note that all dcrdata.org community and team members are expected to adhere to
 the code of conduct, described in the CODE_OF_CONDUCT file.
 
+Also, [come chat with us on Slack](https://join.slack.com/t/dcrdata/shared_invite/enQtMjQ2NzAzODk0MjQ3LTRkZGJjOWIyNDc0MjBmOThhN2YxMzZmZGRlYmVkZmNkNmQ3MGQyNzAxMzJjYzU1MzA2ZGIwYTIzMTUxMjM3ZDY)!
+
 ## License
 
 This project is licensed under the ISC License. See the [LICENSE](LICENSE) file for details.

--- a/blockdata/blockdata.go
+++ b/blockdata/blockdata.go
@@ -31,6 +31,7 @@ type BlockData struct {
 	ExtraInfo        apitypes.BlockExplorerExtraInfo
 	PriceWindowNum   int
 	IdxBlockInWindow int
+	WinningTickets   []string
 }
 
 // ToStakeInfoExtended returns an apitypes.StakeInfoExtended object from the
@@ -159,12 +160,12 @@ func (t *Collector) CollectBlockInfo(hash *chainhash.Hash) (*apitypes.BlockDataB
 	var found bool
 	if ticketPoolInfo, found = t.stakeDB.PoolInfo(*hash); !found {
 		log.Infof("Unable to find block (%s) in pool info cache, trying best block.", hash.String())
-		tpi, sdbHeight := t.stakeDB.PoolInfoBest()
-		if sdbHeight != height {
-			log.Warnf("Collected block height %d != stake db height %d. Pool info "+
-				"will not match the rest of this block's data.", height, sdbHeight)
+		ticketPoolInfo = t.stakeDB.PoolInfoBest()
+		if ticketPoolInfo.Height != height {
+			log.Warnf("Collected block height %d != stake db height %d. Pool "+
+				"info will not match the rest of this block's data.",
+				height, ticketPoolInfo.Height)
 		}
-		ticketPoolInfo = &tpi
 	}
 
 	// Fee info

--- a/cmd/rebuilddb2/.gitignore
+++ b/cmd/rebuilddb2/.gitignore
@@ -1,3 +1,4 @@
 ffldb_stake/
 rebuilddb2
 rebuilddb2.conf
+pg_rebuild_stakedb

--- a/cmd/rebuilddb2/config.go
+++ b/cmd/rebuilddb2/config.go
@@ -50,12 +50,13 @@ type config struct {
 	CPUProfile  string `long:"cpuprofile" description:"File for CPU profiling."`
 
 	// DB
-	DBHostPort          string `long:"dbhost" description:"DB host"`
-	DBUser              string `long:"dbuser" description:"DB user"`
-	DBPass              string `long:"dbpass" description:"DB pass"`
-	DBName              string `long:"dbname" description:"DB name"`
-	DropDBTables        bool   `short:"D" long:"droptables" description:"Drop/delete DB tables."`
-	AddrSpendInfoOnline bool   `short:"a" long:"addrspends-no-batch" description:"Continually update the address table spending transaction info during rebuild (instead of full table update at end).  SLOW if doing full rebuild!"`
+	DBHostPort            string `long:"dbhost" description:"DB host"`
+	DBUser                string `long:"dbuser" description:"DB user"`
+	DBPass                string `long:"dbpass" description:"DB pass"`
+	DBName                string `long:"dbname" description:"DB name"`
+	DropDBTables          bool   `short:"D" long:"droptables" description:"Drop/delete DB tables."`
+	AddrSpendInfoOnline   bool   `short:"a" long:"addrspends-no-batch" description:"Continually update the address table spending transaction info during rebuild (instead of full table update at end).  SLOW if doing full rebuild!"`
+	TicketSpendInfoOnline bool   `short:"t" long:"ticketspends-no-batch" description:"Continually update the tickets table spending transaction info during rebuild (instead of full table update at end).  SLOW if doing full rebuild!"`
 
 	// RPC client options
 	DcrdUser         string `long:"dcrduser" description:"Daemon RPC user name"`

--- a/cmd/rebuilddb2/config.go
+++ b/cmd/rebuilddb2/config.go
@@ -55,7 +55,7 @@ type config struct {
 	DBPass              string `long:"dbpass" description:"DB pass"`
 	DBName              string `long:"dbname" description:"DB name"`
 	DropDBTables        bool   `short:"D" long:"droptables" description:"Drop/delete DB tables."`
-	UpdateAddrSpendInfo bool   `short:"u" long:"updateaddrspends" description:"Update the spending transaction info in ALL rows of the addresses table."`
+	AddrSpendInfoOnline bool   `short:"a" long:"addrspends-no-batch" description:"Continually update the address table spending transaction info during rebuild (instead of full table update at end).  SLOW if doing full rebuild!"`
 
 	// RPC client options
 	DcrdUser         string `long:"dcrduser" description:"Daemon RPC user name"`

--- a/cmd/rebuilddb2/config.go
+++ b/cmd/rebuilddb2/config.go
@@ -50,13 +50,15 @@ type config struct {
 	CPUProfile  string `long:"cpuprofile" description:"File for CPU profiling."`
 
 	// DB
-	DBHostPort            string `long:"dbhost" description:"DB host"`
-	DBUser                string `long:"dbuser" description:"DB user"`
-	DBPass                string `long:"dbpass" description:"DB pass"`
-	DBName                string `long:"dbname" description:"DB name"`
-	DropDBTables          bool   `short:"D" long:"droptables" description:"Drop/delete DB tables."`
-	AddrSpendInfoOnline   bool   `short:"a" long:"addrspends-no-batch" description:"Continually update the address table spending transaction info during rebuild (instead of full table update at end).  SLOW if doing full rebuild!"`
-	TicketSpendInfoOnline bool   `short:"t" long:"ticketspends-no-batch" description:"Continually update the tickets table spending transaction info during rebuild (instead of full table update at end).  SLOW if doing full rebuild!"`
+	DBHostPort             string `long:"dbhost" description:"DB host"`
+	DBUser                 string `long:"dbuser" description:"DB user"`
+	DBPass                 string `long:"dbpass" description:"DB pass"`
+	DBName                 string `long:"dbname" description:"DB name"`
+	DuplicateEntryRecovery bool   `short:"r" long:"recoverfromdups" description:"Remove duplicate entries from all tables which would be prevented by the unique indexes. May be necessary to recover from an ill-timed crash."`
+	DropDBTables           bool   `short:"D" long:"droptables" description:"Drop/delete DB tables."`
+	ForceReindex           bool   `long:"reindex" short:"R" description:"Drop indexes prior to sync and recreate after sync, with insertion conflict checks disabled in absence of constraints."`
+	AddrSpendInfoOnline    bool   `short:"a" long:"addrspends-no-batch" description:"Continually update the address table spending transaction info during rebuild (instead of full table update at end).  SLOW if doing full rebuild!"`
+	TicketSpendInfoBatch   bool   `short:"T" long:"ticketspends-batch" description:"Batch update the tickets table spending transaction info after rebuild (instead of during the rebuild)."`
 
 	// RPC client options
 	DcrdUser         string `long:"dcrduser" description:"Daemon RPC user name"`
@@ -64,12 +66,6 @@ type config struct {
 	DcrdServ         string `long:"dcrdserv" description:"Hostname/IP and port of dcrd RPC server to connect to (default localhost:9109, testnet: localhost:19109, simnet: localhost:19556)"`
 	DcrdCert         string `long:"dcrdcert" description:"File containing the dcrd certificate file"`
 	DisableDaemonTLS bool   `long:"nodaemontls" description:"Disable TLS for the daemon RPC client -- NOTE: This is only allowed if the RPC client is connecting to localhost"`
-
-	ForceReindex bool `long:"reindex" short:"R" description:"Drop indexes prior to sync and recreate after sync, with insertion conflict checks disabled in absence of constraints."`
-	// TODO
-	//AccountName   string `long:"accountname" description:"Account name (other than default or imported) for which balances should be listed."`
-	//TicketAddress string `long:"ticketaddress" description:"Address to which you have given voting rights"`
-	//PoolAddress   string `long:"pooladdress" description:"Address to which you have given rights to pool fees"`
 }
 
 var (

--- a/cmd/rebuilddb2/config.go
+++ b/cmd/rebuilddb2/config.go
@@ -47,7 +47,9 @@ type config struct {
 	DebugLevel  string `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}"`
 	Quiet       bool   `short:"q" long:"quiet" description:"Easy way to set debuglevel to error"`
 	LogDir      string `long:"logdir" description:"Directory to log output"`
+	HTTPProfile bool   `long:"httpprof" short:"p" description:"Start HTTP profiler."`
 	CPUProfile  string `long:"cpuprofile" description:"File for CPU profiling."`
+	MemProfile  string `long:"memprofile" description:"File for mempry profiling."`
 
 	// DB
 	DBHostPort             string `long:"dbhost" description:"DB host"`

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -275,7 +275,7 @@ func mainCore() error {
 
 		var numVins, numVouts int64
 		numVins, numVouts, err = db.StoreBlock(block.MsgBlock(), winners,
-			true, !cfg.UpdateAddrSpendInfo)
+			true, cfg.AddrSpendInfoOnline)
 		if err != nil {
 			return fmt.Errorf("StoreBlock failed: %v", err)
 		}
@@ -300,12 +300,13 @@ func mainCore() error {
 		if err = db.IndexAll(); err != nil {
 			return fmt.Errorf("IndexAll failed: %v", err)
 		}
-		if !cfg.UpdateAddrSpendInfo {
+		// Only reindex address table here if we do not do it below
+		if cfg.AddrSpendInfoOnline {
 			err = db.IndexAddressTable()
 		}
 	}
 
-	if cfg.UpdateAddrSpendInfo {
+	if !cfg.AddrSpendInfoOnline {
 		// Remove existing indexes not on funding txns
 		_ = db.DeindexAddressTable() // ignore errors for non-existent indexes
 		log.Infof("Populating spending tx info in address table...")

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -325,6 +325,35 @@ func mainCore() error {
 		// TODO: remove entries from addresses table that reference removed
 		// vins/vouts.
 
+		// Remove duplicate transactions
+		log.Info("Finding and removing duplicate transactions entries before indexing...")
+		var numTxnsRemoved int64
+		if numTxnsRemoved, err = db.DeleteDuplicateTxns(); err != nil {
+			return fmt.Errorf("dcrpg.DeleteDuplicateTxns failed: %v", err)
+		}
+		log.Infof("Removed %d duplicate transactions entries.", numTxnsRemoved)
+
+		// Remove duplicate tickets
+		log.Info("Finding and removing duplicate tickets entries before indexing...")
+		if numTxnsRemoved, err = db.DeleteDuplicateTickets(); err != nil {
+			return fmt.Errorf("dcrpg.DeleteDuplicateTickets failed: %v", err)
+		}
+		log.Infof("Removed %d duplicate tickets entries.", numTxnsRemoved)
+
+		// Remove duplicate votes
+		log.Info("Finding and removing duplicate votes entries before indexing...")
+		if numTxnsRemoved, err = db.DeleteDuplicateVotes(); err != nil {
+			return fmt.Errorf("dcrpg.DeleteDuplicateVotes failed: %v", err)
+		}
+		log.Infof("Removed %d duplicate votes entries.", numTxnsRemoved)
+
+		// Remove duplicate misses
+		log.Info("Finding and removing duplicate misses entries before indexing...")
+		if numTxnsRemoved, err = db.DeleteDuplicateMisses(); err != nil {
+			return fmt.Errorf("dcrpg.DeleteDuplicateMisses failed: %v", err)
+		}
+		log.Infof("Removed %d duplicate misses entries.", numTxnsRemoved)
+
 		// Create indexes
 		if err = db.IndexAll(); err != nil {
 			return fmt.Errorf("IndexAll failed: %v", err)
@@ -338,6 +367,7 @@ func mainCore() error {
 	if !cfg.AddrSpendInfoOnline {
 		// Remove indexes not on funding txns (remove on address table indexes)
 		_ = db.DeindexAddressTable() // ignore errors for non-existent indexes
+		db.EnableDuplicateCheckOnInsert(false)
 		log.Infof("Populating spending tx info in address table...")
 		numAddresses, err := db.UpdateSpendingInfoInAllAddresses()
 		if err != nil {

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -134,6 +134,10 @@ func mainCore() error {
 		return nil
 	}
 
+	if err = db.VersionCheck(); err != nil {
+		log.Warnf("ATTENTION: %v", err)
+	}
+
 	if cfg.DuplicateEntryRecovery {
 		return db.DeleteDuplicatesRecovery()
 	}

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -284,7 +284,7 @@ func mainCore() error {
 
 		var numVins, numVouts int64
 		numVins, numVouts, err = db.StoreBlock(block.MsgBlock(), winners,
-			true, cfg.AddrSpendInfoOnline)
+			true, cfg.AddrSpendInfoOnline, cfg.TicketSpendInfoOnline)
 		if err != nil {
 			return fmt.Errorf("StoreBlock failed: %v", err)
 		}
@@ -306,53 +306,9 @@ func mainCore() error {
 	speedReport()
 
 	if reindexing || cfg.ForceReindex {
-		// Remove duplicate vins
-		log.Info("Finding and removing duplicate vins entries before indexing...")
-		var numVinsRemoved int64
-		if numVinsRemoved, err = db.DeleteDuplicateVins(); err != nil {
-			return fmt.Errorf("dcrpg.DeleteDuplicateVins failed: %v", err)
+		if err = db.DeleteDuplicates(); err != nil {
+			return err
 		}
-		log.Infof("Removed %d duplicate vins entries.", numVinsRemoved)
-
-		// Remove duplicate vouts
-		log.Info("Finding and removing duplicate vouts entries before indexing...")
-		var numVoutsRemoved int64
-		if numVoutsRemoved, err = db.DeleteDuplicateVouts(); err != nil {
-			return fmt.Errorf("dcrpg.DeleteDuplicateVouts failed: %v", err)
-		}
-		log.Infof("Removed %d duplicate vouts entries.", numVoutsRemoved)
-
-		// TODO: remove entries from addresses table that reference removed
-		// vins/vouts.
-
-		// Remove duplicate transactions
-		log.Info("Finding and removing duplicate transactions entries before indexing...")
-		var numTxnsRemoved int64
-		if numTxnsRemoved, err = db.DeleteDuplicateTxns(); err != nil {
-			return fmt.Errorf("dcrpg.DeleteDuplicateTxns failed: %v", err)
-		}
-		log.Infof("Removed %d duplicate transactions entries.", numTxnsRemoved)
-
-		// Remove duplicate tickets
-		log.Info("Finding and removing duplicate tickets entries before indexing...")
-		if numTxnsRemoved, err = db.DeleteDuplicateTickets(); err != nil {
-			return fmt.Errorf("dcrpg.DeleteDuplicateTickets failed: %v", err)
-		}
-		log.Infof("Removed %d duplicate tickets entries.", numTxnsRemoved)
-
-		// Remove duplicate votes
-		log.Info("Finding and removing duplicate votes entries before indexing...")
-		if numTxnsRemoved, err = db.DeleteDuplicateVotes(); err != nil {
-			return fmt.Errorf("dcrpg.DeleteDuplicateVotes failed: %v", err)
-		}
-		log.Infof("Removed %d duplicate votes entries.", numTxnsRemoved)
-
-		// Remove duplicate misses
-		log.Info("Finding and removing duplicate misses entries before indexing...")
-		if numTxnsRemoved, err = db.DeleteDuplicateMisses(); err != nil {
-			return fmt.Errorf("dcrpg.DeleteDuplicateMisses failed: %v", err)
-		}
-		log.Infof("Removed %d duplicate misses entries.", numTxnsRemoved)
 
 		// Create indexes
 		if err = db.IndexAll(); err != nil {
@@ -361,6 +317,9 @@ func mainCore() error {
 		// Only reindex address table here if we do not do it below
 		if cfg.AddrSpendInfoOnline {
 			err = db.IndexAddressTable()
+		}
+		if cfg.TicketSpendInfoOnline {
+			err = db.IndexTicketsTable()
 		}
 	}
 
@@ -377,6 +336,22 @@ func mainCore() error {
 		log.Infof("Updated %d rows of address table", numAddresses)
 		if err = db.IndexAddressTable(); err != nil {
 			log.Errorf("IndexAddressTable FAILED: %v", err)
+		}
+	}
+
+	if !cfg.TicketSpendInfoOnline {
+		// Remove indexes not on funding txns (remove on address table indexes)
+		_ = db.DeindexTicketsTable() // ignore errors for non-existent indexes
+		db.EnableDuplicateCheckOnInsert(false)
+		log.Infof("Populating spending tx info in tickets table...")
+		numTicketsUpdated, err := db.UpdateSpendingInfoInAllTickets()
+		if err != nil {
+			log.Errorf("UpdateSpendingInfoInAllTickets FAILED: %v", err)
+		}
+		// Index tickets table
+		log.Infof("Updated %d rows of address table", numTicketsUpdated)
+		if err = db.IndexTicketsTable(); err != nil {
+			log.Errorf("IndexTicketsTable FAILED: %v", err)
 		}
 	}
 

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -111,10 +111,6 @@ func mainCore() error {
 		return nil
 	}
 
-	if err = db.SetupTables(); err != nil {
-		return err
-	}
-
 	// Ctrl-C to shut down.
 	// Nothing should be sent the quit channel.  It should only be closed.
 	quit := make(chan struct{})

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -200,6 +200,14 @@ func mainCore() error {
 		log.Infof("Advancing stake db from %d to %d...", stakeDBHeight, lastBlock)
 	}
 	for stakeDBHeight < lastBlock {
+		// check for quit signal
+		select {
+		case <-quit:
+			log.Infof("Rescan cancelled at height %d.", stakeDBHeight)
+			return nil
+		default:
+		}
+
 		block, blockHash, err := rpcutils.GetBlock(stakeDBHeight+1, client)
 		if err != nil {
 			return fmt.Errorf("GetBlock failed (%s): %v", blockHash, err)

--- a/cmd/rebuilddb2/rebuilddb2.go
+++ b/cmd/rebuilddb2/rebuilddb2.go
@@ -24,6 +24,7 @@ var (
 	backendLog      *btclog.Backend
 	rpcclientLogger btclog.Logger
 	pgLogger        btclog.Logger
+	stakedbLogger   btclog.Logger
 )
 
 const (
@@ -41,6 +42,8 @@ func init() {
 	rpcclient.UseLogger(rpcclientLogger)
 	pgLogger = backendLog.Logger("PSQL")
 	dcrpg.UseLogger(pgLogger)
+	stakedbLogger = backendLog.Logger("SKDB")
+	stakedb.UseLogger(stakedbLogger)
 }
 
 func mainCore() error {
@@ -125,7 +128,7 @@ func mainCore() error {
 	if db != nil {
 		defer db.Close()
 	}
-	if err != nil {
+	if err != nil || db == nil {
 		return err
 	}
 

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -263,27 +263,27 @@ type ScriptSig struct {
 // Tx models a Decred transaction. It is stored in a Block.
 type Tx struct {
 	//blockDbID  int64
-	BlockHash   string             `json:"block_hash"`
-	BlockHeight int64              `json:"block_height"`
-	BlockTime   int64              `json:"block_time"`
-	Time        int64              `json:"time"`
-	TxType      int16              `json:"tx_type"`
-	Version     uint16             `json:"version"`
-	Tree        int8               `json:"tree"`
-	TxID        string             `json:"txid"`
-	BlockIndex  uint32             `json:"block_index"`
-	Locktime    uint32             `json:"locktime"`
-	Expiry      uint32             `json:"expiry"`
-	Size        uint32             `json:"size"`
-	Spent       int64              `json:"spent"`
-	Sent        int64              `json:"sent"`
-	Fees        int64              `json:"fees"`
-	NumVin      uint32             `json:"numvin"`
-	Vins        VinTxPropertyARRAY `json:"vins"`
-	VinDbIds    []uint64           `json:"vindbids"`
-	NumVout     uint32             `json:"numvout"`
-	Vouts       []*Vout            `json:"vouts"`
-	VoutDbIds   []uint64           `json:"voutdbids"`
+	BlockHash   string `json:"block_hash"`
+	BlockHeight int64  `json:"block_height"`
+	BlockTime   int64  `json:"block_time"`
+	Time        int64  `json:"time"`
+	TxType      int16  `json:"tx_type"`
+	Version     uint16 `json:"version"`
+	Tree        int8   `json:"tree"`
+	TxID        string `json:"txid"`
+	BlockIndex  uint32 `json:"block_index"`
+	Locktime    uint32 `json:"locktime"`
+	Expiry      uint32 `json:"expiry"`
+	Size        uint32 `json:"size"`
+	Spent       int64  `json:"spent"`
+	Sent        int64  `json:"sent"`
+	Fees        int64  `json:"fees"`
+	NumVin      uint32 `json:"numvin"`
+	//Vins        VinTxPropertyARRAY `json:"vins"`
+	VinDbIds  []uint64 `json:"vindbids"`
+	NumVout   uint32   `json:"numvout"`
+	Vouts     []*Vout  `json:"vouts"`
+	VoutDbIds []uint64 `json:"voutdbids"`
 	// NOTE: VoutDbIds may not be needed if there is a vout table since each
 	// vout will have a tx_dbid
 }

--- a/db/dbtypes/types.go
+++ b/db/dbtypes/types.go
@@ -9,6 +9,56 @@ import (
 	"github.com/dcrdata/dcrdata/db/dbtypes/internal"
 )
 
+// Tickets have 6 states, 5 possible fates:
+// Live -...---> Voted
+//           \-> Missed (unspent) [--> Revoked]
+//            \--...--> Expired (unspent) [--> Revoked]
+
+type TicketSpendType int16
+
+const (
+	TicketUnspent TicketSpendType = iota
+	TicketRevoked
+	TicketVoted
+)
+
+func (p TicketSpendType) String() string {
+	switch p {
+	case TicketUnspent:
+		return "unspent"
+	case TicketRevoked:
+		return "revoked"
+	case TicketVoted:
+		return "voted"
+	default:
+		return "unknown"
+	}
+}
+
+type TicketPoolStatus int16
+
+const (
+	PoolStatusLive TicketPoolStatus = iota
+	PoolStatusVoted
+	PoolStatusExpired
+	PoolStatusMissed
+)
+
+func (p TicketPoolStatus) String() string {
+	switch p {
+	case PoolStatusLive:
+		return "live"
+	case PoolStatusVoted:
+		return "voted"
+	case PoolStatusExpired:
+		return "expired"
+	case PoolStatusMissed:
+		return "missed"
+	default:
+		return "unknown"
+	}
+}
+
 // SyncResult is the result of a database sync operation, containing the height
 // of the last block and an arror value.
 type SyncResult struct {

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -55,7 +55,8 @@ const (
 	SelectAddressIDsByFundingOutpoint = `SELECT id, address FROM addresses
 		WHERE funding_tx_hash=$1 and funding_tx_vout_index=$2;`
 	SelectAddressIDByVoutIDAddress = `SELECT id FROM addresses
-		WHERE address=$1 and vout_row_id=$2;`
+		WHERE address=$1 and vout_row_id=$2
+		ORDER BY id DESC;`
 
 	SetAddressSpendingForID = `UPDATE addresses SET spending_tx_row_id = $2, 
 		spending_tx_hash = $3, spending_tx_vin_index = $4, vin_row_id = $5 

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -6,12 +6,12 @@ const (
 		VALUES ($1, $2, $3, $4, $5, $6) `
 	InsertAddressRow = insertAddressRow0 + `RETURNING id;`
 	// InsertAddressRowChecked = insertAddressRow0 +
-	// 	`ON CONFLICT (address, vout_row_id) DO NOTHING RETURNING id;`
-	UpsertAddressRow = insertAddressRow0 + `ON CONFLICT (address, vout_row_id) DO UPDATE 
+	// 	`ON CONFLICT (vout_row_id, address) DO NOTHING RETURNING id;`
+	UpsertAddressRow = insertAddressRow0 + `ON CONFLICT (vout_row_id, address) DO UPDATE 
 		SET address = $1, vout_row_id = $5 RETURNING id;`
 	InsertAddressRowReturnID = `WITH inserting AS (` +
 		insertAddressRow0 +
-		`ON CONFLICT (address, vout_row_id) DO UPDATE
+		`ON CONFLICT (vout_row_id, address) DO UPDATE
 		SET address = NULL WHERE FALSE
 		RETURNING id
 		)
@@ -70,7 +70,7 @@ const (
 	DeindexAddressTableOnAddress = `DROP INDEX uix_addresses_address;`
 
 	IndexAddressTableOnVoutID = `CREATE UNIQUE INDEX uix_addresses_vout_id
-		ON addresses(vout_row_id);`
+		ON addresses(vout_row_id, address);`
 	DeindexAddressTableOnVoutID = `DROP INDEX uix_addresses_vout_id;`
 
 	IndexAddressTableOnFundingTx = `CREATE INDEX uix_addresses_funding_tx

--- a/db/dcrpg/internal/addrstmts.go
+++ b/db/dcrpg/internal/addrstmts.go
@@ -4,9 +4,11 @@ const (
 	insertAddressRow0 = `INSERT INTO addresses (address, funding_tx_row_id,
 		funding_tx_hash, funding_tx_vout_index, vout_row_id, value)
 		VALUES ($1, $2, $3, $4, $5, $6) `
-	InsertAddressRow        = insertAddressRow0 + `RETURNING id;`
-	InsertAddressRowChecked = insertAddressRow0 +
-		`ON CONFLICT (address, vout_row_id) DO NOTHING RETURNING id;`
+	InsertAddressRow = insertAddressRow0 + `RETURNING id;`
+	// InsertAddressRowChecked = insertAddressRow0 +
+	// 	`ON CONFLICT (address, vout_row_id) DO NOTHING RETURNING id;`
+	UpsertAddressRow = insertAddressRow0 + `ON CONFLICT (address, vout_row_id) DO UPDATE 
+		SET address = $1, vout_row_id = $5 RETURNING id;`
 	InsertAddressRowReturnID = `WITH inserting AS (` +
 		insertAddressRow0 +
 		`ON CONFLICT (address, vout_row_id) DO UPDATE

--- a/db/dcrpg/internal/blockstmts.go
+++ b/db/dcrpg/internal/blockstmts.go
@@ -19,8 +19,10 @@ const (
 		$11, $12, $13, $14, $15, 
 		$16, $17, $18, $19, $20,
 		$21, $22, $23, $24) `
-	insertBlockRow         = insertBlockRow0 + `RETURNING id;`
-	insertBlockRowChecked  = insertBlockRow0 + `ON CONFLICT (hash) DO NOTHING RETURNING id;`
+	insertBlockRow = insertBlockRow0 + `RETURNING id;`
+	// insertBlockRowChecked  = insertBlockRow0 + `ON CONFLICT (hash) DO NOTHING RETURNING id;`
+	upsertBlockRow = insertBlockRow0 + `ON CONFLICT (hash) DO UPDATE 
+		SET hash = $1 RETURNING id;`
 	insertBlockRowReturnId = `WITH ins AS (` +
 		insertBlockRow0 +
 		`ON CONFLICT (hash) DO UPDATE
@@ -103,7 +105,7 @@ func makeBlockInsertStatement(txDbIDs, stxDbIDs []uint64, rtxs, stxs []string, c
 	stxTEXTARRAY := makeARRAYOfTEXT(stxs)
 	var insert string
 	if checked {
-		insert = insertBlockRowChecked
+		insert = upsertBlockRow
 	} else {
 		insert = insertBlockRow
 	}

--- a/db/dcrpg/internal/common.go
+++ b/db/dcrpg/internal/common.go
@@ -2,6 +2,19 @@ package internal
 
 import "fmt"
 
+const (
+	IndexExists = `SELECT 1
+FROM   pg_class c
+JOIN   pg_namespace n ON n.oid = c.relnamespace
+WHERE  c.relname = $1 AND n.nspname = $2;`
+
+	IndexIsUnique = `SELECT indisunique
+FROM   pg_index i
+JOIN   pg_class c ON c.oid = i.indexrelid
+JOIN   pg_namespace n ON n.oid = c.relnamespace
+WHERE  c.relname = $1 AND n.nspname = $2`
+)
+
 func makeARRAYOfTEXT(text []string) string {
 	if len(text) == 0 {
 		return "ARRAY['']"

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -19,12 +19,10 @@ const (
 	// Insert
 	insertTicketRow0 = `INSERT INTO tickets (
 		tx_hash, block_hash, block_height, purchase_tx_db_id,
-		stakesubmission_address, is_multisig, num_inputs,
-		spend_height, spend_tx_db_id)
+		stakesubmission_address, is_multisig, num_inputs)
 	VALUES (
 		$1, $2, $3,	$4,
-		$5, $6, $7,
-		$8, $9);`
+		$5, $6, $7);`
 	insertTicketRow        = insertTicketRow0 + `RETURNING id;`
 	insertTicketRowChecked = insertTicketRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertTicketRow        = insertTicketRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
@@ -110,3 +108,17 @@ const (
 		ON votes(version);`
 	DeindexVotesTableOnVoteVersion = `DROP INDEX uix_votes_vote_version;`
 )
+
+func MakeTicketInsertStatement(checked bool) string {
+	if checked {
+		return insertTicketRowChecked
+	}
+	return insertTicketRow
+}
+
+func MakeVoteInsertStatement(checked bool) string {
+	if checked {
+		return insertVoteRowChecked
+	}
+	return insertVoteRow
+}

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -22,11 +22,11 @@ const (
 		stakesubmission_address, is_multisig, num_inputs)
 	VALUES (
 		$1, $2, $3,	$4,
-		$5, $6, $7);`
+		$5, $6, $7) `
 	insertTicketRow        = insertTicketRow0 + `RETURNING id;`
 	insertTicketRowChecked = insertTicketRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertTicketRow        = insertTicketRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
-		SET tx_hash = $1, block_hash = $2, RETURNING id;`
+		SET tx_hash = $1, block_hash = $2 RETURNING id;`
 	insertTicketRowReturnId = `WITH ins AS (` +
 		insertTicketRow0 +
 		`ON CONFLICT (tx_hash, block_hash) DO UPDATE
@@ -78,11 +78,11 @@ const (
 	VALUES (
 		$1, $2, $3,
 		$4, $5,
-		$6, $7, $8);`
+		$6, $7, $8) `
 	insertVoteRow        = insertVoteRow0 + `RETURNING id;`
 	insertVoteRowChecked = insertVoteRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertVoteRow        = insertVoteRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
-		SET tx_hash = $3, block_hash = $4, RETURNING id;`
+		SET tx_hash = $3, block_hash = $4 RETURNING id;`
 	insertVoteRowReturnId = `WITH ins AS (` +
 		insertVoteRow0 +
 		`ON CONFLICT (tx_hash, block_hash) DO UPDATE

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -44,6 +44,12 @@ const (
 	WHERE  tx_hash = $1 AND block_hash = $2
 	LIMIT  1;`
 
+	SelectTicketsInBlock         = `SELECT * FROM tickets WHERE block_hash = $1;`
+	SelectTicketsTxDbIDsInBlock  = `SELECT purchase_tx_db_id FROM tickets WHERE block_hash = $1;`
+	SelectTicketsForAddress      = `SELECT * FROM tickets WHERE stakesubmission_address = $1;`
+	SelectTicketsForPriceAtLeast = `SELECT * FROM tickets WHERE price >= $1;`
+	SelectTicketsForPriceAtMost  = `SELECT * FROM tickets WHERE price <= $1;`
+
 	// Update
 	SetTicketSpendingInfoForHash = `UPDATE tickets
 		SET spend_height = $3, spend_tx_db_id = $4

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -67,6 +67,13 @@ const (
 		ON tickets(purchase_tx_db_id);`
 	DeindexTicketsTableOnTxDbID = `DROP INDEX uix_ticket_ticket_db_id;`
 
+	DeleteTicketsDuplicateRows = `DELETE FROM tickets
+		WHERE id IN (SELECT id FROM (
+				SELECT id, ROW_NUMBER()
+				OVER (partition BY tx_hash, block_hash ORDER BY id) AS rnum
+				FROM tickets) t
+			WHERE t.rnum > 1);`
+
 	// Votes
 
 	CreateVotesTable = `CREATE TABLE IF NOT EXISTS votes (
@@ -123,6 +130,13 @@ const (
 		ON votes(version);`
 	DeindexVotesTableOnVoteVersion = `DROP INDEX uix_votes_vote_version;`
 
+	DeleteVotesDuplicateRows = `DELETE FROM votes
+		WHERE id IN (SELECT id FROM (
+				SELECT id, ROW_NUMBER()
+				OVER (partition BY tx_hash, block_hash ORDER BY id) AS rnum
+				FROM votes) t
+			WHERE t.rnum > 1);`
+
 	// Misses
 
 	CreateMissesTable = `CREATE TABLE IF NOT EXISTS misses (
@@ -158,6 +172,13 @@ const (
 	IndexMissesTableOnHashes = `CREATE UNIQUE INDEX uix_misses_hashes_index
 		ON misses(ticket_hash, block_hash);`
 	DeindexMissesTableOnHashes = `DROP INDEX uix_misses_hashes_index;`
+
+	DeleteMissesDuplicateRows = `DELETE FROM misses
+		WHERE id IN (SELECT id FROM (
+				SELECT id, ROW_NUMBER()
+				OVER (partition BY ticket_hash, block_hash ORDER BY id) AS rnum
+				FROM misses) t
+			WHERE t.rnum > 1);`
 )
 
 func MakeTicketInsertStatement(checked bool) string {

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -1,0 +1,112 @@
+package internal
+
+const (
+	// Tickets
+
+	CreateTicketsTable = `CREATE TABLE IF NOT EXISTS tickets (  
+		id SERIAL PRIMARY KEY,
+		tx_hash TEXT NOT NULL,
+		block_hash TEXT NOT NULL,
+		block_height INT4,
+		purchase_tx_db_id INT8,
+		stakesubmission_address TEXT,
+		is_multisig BOOLEAN,
+		num_inputs INT2,
+		spend_height INT4,
+		spend_tx_db_id INT8
+	);`
+
+	// Insert
+	insertTicketRow0 = `INSERT INTO tickets (
+		tx_hash, block_hash, block_height, purchase_tx_db_id,
+		stakesubmission_address, is_multisig, num_inputs,
+		spend_height, spend_tx_db_id)
+	VALUES (
+		$1, $2, $3,	$4,
+		$5, $6, $7,
+		$8, $9);`
+	insertTicketRow        = insertTicketRow0 + `RETURNING id;`
+	insertTicketRowChecked = insertTicketRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
+	upsertTicketRow        = insertTicketRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
+		SET tx_hash = $1, block_hash = $2, RETURNING id;`
+	insertTicketRowReturnId = `WITH ins AS (` +
+		insertTicketRow0 +
+		`ON CONFLICT (tx_hash, block_hash) DO UPDATE
+		SET tx_hash = NULL WHERE FALSE
+		RETURNING id
+		)
+	SELECT id FROM ins
+	UNION  ALL
+	SELECT id FROM tickets
+	WHERE  tx_hash = $1 AND block_hash = $2
+	LIMIT  1;`
+
+	// Update
+	SetTicketSpendingInfoForHash = `UPDATE tickets
+		SET spend_height = $3, spend_tx_db_id = $4
+		WHERE tx_hash = $1 and block_hash = $2;`
+	SetTicketSpendingInfoForTxDbID = `UPDATE tickets
+		SET spend_height = $2, spend_tx_db_id = $3
+		WHERE purchase_tx_db_id = $1;`
+
+	// Index
+	IndexTicketsTableOnHashes = `CREATE UNIQUE INDEX uix_ticket_hashes_index
+		ON tickets(tx_hash, block_hash);`
+	DeindexTicketsTableOnHashes = `DROP INDEX uix_ticket_hashes_index;`
+
+	IndexTicketsTableOnTxDbID = `CREATE UNIQUE INDEX uix_ticket_ticket_db_id
+		ON tickets(purchase_tx_db_id);`
+	DeindexTicketsTableOnTxDbID = `DROP INDEX uix_ticket_ticket_db_id;`
+
+	// Votes
+
+	CreateVotesTable = `CREATE TABLE IF NOT EXISTS votes (
+		id SERIAL PRIMARY KEY,
+		height INT4,
+		missed BOOLEAN,
+		tx_hash TEXT NOT NULL,
+		block_hash TEXT NOT NULL,
+		candidate_block_hash TEXT NOT NULL,
+		version INT2,
+		vote_bits INT2,
+		block_valid BOOLEAN
+	);`
+
+	// Insert
+	insertVoteRow0 = `INSERT INTO votes (
+		height, missed, tx_hash,
+		block_hash, candidate_block_hash,
+		version, vote_bits, block_valid)
+	VALUES (
+		$1, $2, $3,
+		$4, $5,
+		$6, $7, $8);`
+	insertVoteRow        = insertVoteRow0 + `RETURNING id;`
+	insertVoteRowChecked = insertVoteRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
+	upsertVoteRow        = insertVoteRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
+		SET tx_hash = $3, block_hash = $4, RETURNING id;`
+	insertVoteRowReturnId = `WITH ins AS (` +
+		insertVoteRow0 +
+		`ON CONFLICT (tx_hash, block_hash) DO UPDATE
+		SET tx_hash = NULL WHERE FALSE
+		RETURNING id
+		)
+	SELECT id FROM ins
+	UNION  ALL
+	SELECT id FROM votes
+	WHERE  tx_hash = $3 AND block_hash = $4
+	LIMIT  1;`
+
+	// Index
+	IndexVotesTableOnHashes = `CREATE UNIQUE INDEX uix_votes_hashes_index
+		ON votes(tx_hash, block_hash);`
+	DeindexVotesTableOnHashes = `DROP INDEX uix_votes_hashes_index;`
+
+	IndexVotesTableOnCandidate = `CREATE INDEX uix_votes_candidate_block
+		ON votes(candidate_block_hash);`
+	DeindexVotesTableOnCandidate = `DROP INDEX uix_votes_candidate_block;`
+
+	IndexVotesTableOnVoteVersion = `CREATE INDEX uix_votes_vote_version
+		ON votes(version);`
+	DeindexVotesTableOnVoteVersion = `DROP INDEX uix_votes_vote_version;`
+)

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -53,6 +53,7 @@ const (
 	SelectTicketsForPriceAtMost  = `SELECT * FROM tickets WHERE price <= $1;`
 	SelectTicketIDHeightByHash   = `SELECT id, block_height FROM tickets WHERE tx_hash = $1;`
 	SelectTicketIDByHash         = `SELECT id FROM tickets WHERE tx_hash = $1;`
+	SelectTicketStatusByHash     = `SELECT id, spend_type, pool_status FROM tickets WHERE tx_hash = $1;`
 	SelectUnspentTickets         = `SELECT id, tx_hash FROM tickets WHERE spend_type = 0 OR spend_type = -1;`
 
 	// Update

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -52,6 +52,7 @@ const (
 	SelectTicketsForPriceAtMost  = `SELECT * FROM tickets WHERE price <= $1;`
 	SelectTicketIDHeightByHash   = `SELECT id, block_height FROM tickets WHERE tx_hash = $1;`
 	SelectTicketIDByHash         = `SELECT id FROM tickets WHERE tx_hash = $1;`
+	SelectUnspentTickets         = `SELECT id, tx_hash FROM tickets WHERE spend_type = 0 OR spend_type = -1;`
 
 	// Update
 	SetTicketSpendingInfoForHash = `UPDATE tickets
@@ -92,6 +93,7 @@ const (
 		vote_bits INT2,
 		block_valid BOOLEAN,
 		ticket_hash TEXT,
+		ticket_tx_db_id INT8,
 		ticket_price FLOAT8,
 		vote_reward FLOAT8
 	);`
@@ -101,12 +103,12 @@ const (
 		height, tx_hash,
 		block_hash, candidate_block_hash,
 		version, vote_bits, block_valid,
-		ticket_hash, ticket_price, vote_reward)
+		ticket_hash, ticket_tx_db_id, ticket_price, vote_reward)
 	VALUES (
 		$1, $2,
 		$3, $4,
 		$5, $6, $7,
-		$8, $9, $10) `
+		$8, $9, $10, $11) `
 	insertVoteRow = insertVoteRow0 + `RETURNING id;`
 	// insertVoteRowChecked = insertVoteRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertVoteRow = insertVoteRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
@@ -124,6 +126,7 @@ const (
 	LIMIT  1;`
 
 	SelectAllVoteDbIDsHeightsTicketHashes = `SELECT id, height, ticket_hash FROM votes;`
+	SelectAllVoteDbIDsHeightsTicketDbIDs  = `SELECT id, height, ticket_tx_db_id FROM votes;`
 
 	// Index
 	IndexVotesTableOnHashes = `CREATE UNIQUE INDEX uix_votes_hashes_index

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -16,6 +16,7 @@ const (
 		price FLOAT8,
 		fee FLOAT8,
 		spend_type INT2,
+		pool_status INT2,
 		spend_height INT4,
 		spend_tx_db_id INT8
 	);`
@@ -24,11 +25,11 @@ const (
 	insertTicketRow0 = `INSERT INTO tickets (
 		tx_hash, block_hash, block_height, purchase_tx_db_id,
 		stakesubmission_address, is_multisig, is_split,
-		num_inputs, price, fee, spend_type)
+		num_inputs, price, fee, spend_type, pool_status)
 	VALUES (
 		$1, $2, $3,	$4,
 		$5, $6, $7,
-		$8, $9, $10, $11) `
+		$8, $9, $10, $11, $12) `
 	insertTicketRow = insertTicketRow0 + `RETURNING id;`
 	// insertTicketRowChecked = insertTicketRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertTicketRow = insertTicketRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
@@ -56,14 +57,16 @@ const (
 
 	// Update
 	SetTicketSpendingInfoForHash = `UPDATE tickets
-		SET spend_type = $5, spend_height = $3, spend_tx_db_id = $4
+		SET spend_type = $5, spend_height = $3, spend_tx_db_id = $4, pool_status = $6
 		WHERE tx_hash = $1 and block_hash = $2;`
 	SetTicketSpendingInfoForTicketDbID = `UPDATE tickets
-		SET spend_type = $4, spend_height = $2, spend_tx_db_id = $3
+		SET spend_type = $4, spend_height = $2, spend_tx_db_id = $3, pool_status = $5
 		WHERE id = $1;`
 	SetTicketSpendingInfoForTxDbID = `UPDATE tickets
-		SET spend_type = $4, spend_height = $2, spend_tx_db_id = $3
+		SET spend_type = $4, spend_height = $2, spend_tx_db_id = $3, pool_status = $5
 		WHERE purchase_tx_db_id = $1;`
+	SetTicketPoolStatusForTicketDbID = `UPDATE tickets SET pool_status = $2 WHERE id = $1;`
+	SetTicketPoolStatusForHash       = `UPDATE tickets SET pool_status = $2 WHERE tx_hash = $1;`
 
 	// Index
 	IndexTicketsTableOnHashes = `CREATE UNIQUE INDEX uix_ticket_hashes_index

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -15,6 +15,7 @@ const (
 		num_inputs INT2,
 		price FLOAT8,
 		fee FLOAT8,
+		spend_type INT2,
 		spend_height INT4,
 		spend_tx_db_id INT8
 	);`
@@ -23,11 +24,11 @@ const (
 	insertTicketRow0 = `INSERT INTO tickets (
 		tx_hash, block_hash, block_height, purchase_tx_db_id,
 		stakesubmission_address, is_multisig, is_split,
-		num_inputs, price, fee)
+		num_inputs, price, fee, spend_type)
 	VALUES (
 		$1, $2, $3,	$4,
 		$5, $6, $7,
-		$8, $9, $10) `
+		$8, $9, $10, $11) `
 	insertTicketRow = insertTicketRow0 + `RETURNING id;`
 	// insertTicketRowChecked = insertTicketRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertTicketRow = insertTicketRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
@@ -49,13 +50,18 @@ const (
 	SelectTicketsForAddress      = `SELECT * FROM tickets WHERE stakesubmission_address = $1;`
 	SelectTicketsForPriceAtLeast = `SELECT * FROM tickets WHERE price >= $1;`
 	SelectTicketsForPriceAtMost  = `SELECT * FROM tickets WHERE price <= $1;`
+	SelectTicketIDHeightByHash   = `SELECT id, block_height FROM tickets WHERE tx_hash = $1;`
+	SelectTicketIDByHash         = `SELECT id FROM tickets WHERE tx_hash = $1;`
 
 	// Update
 	SetTicketSpendingInfoForHash = `UPDATE tickets
-		SET spend_height = $3, spend_tx_db_id = $4
+		SET spend_type = $5, spend_height = $3, spend_tx_db_id = $4
 		WHERE tx_hash = $1 and block_hash = $2;`
+	SetTicketSpendingInfoForTicketDbID = `UPDATE tickets
+		SET spend_type = $4, spend_height = $2, spend_tx_db_id = $3
+		WHERE id = $1;`
 	SetTicketSpendingInfoForTxDbID = `UPDATE tickets
-		SET spend_height = $2, spend_tx_db_id = $3
+		SET spend_type = $4, spend_height = $2, spend_tx_db_id = $3
 		WHERE purchase_tx_db_id = $1;`
 
 	// Index
@@ -116,6 +122,8 @@ const (
 	SELECT id FROM votes
 	WHERE  tx_hash = $3 AND block_hash = $4
 	LIMIT  1;`
+
+	SelectAllVoteDbIDsHeightsTicketHashes = `SELECT id, height, ticket_hash FROM votes;`
 
 	// Index
 	IndexVotesTableOnHashes = `CREATE UNIQUE INDEX uix_votes_hashes_index
@@ -179,6 +187,8 @@ const (
 				OVER (partition BY ticket_hash, block_hash ORDER BY id) AS rnum
 				FROM misses) t
 			WHERE t.rnum > 1);`
+
+	// Revokes?
 )
 
 func MakeTicketInsertStatement(checked bool) string {

--- a/db/dcrpg/internal/stakestmts.go
+++ b/db/dcrpg/internal/stakestmts.go
@@ -179,6 +179,8 @@ const (
 	WHERE  ticket_hash = $4 AND block_hash = $2
 	LIMIT  1;`
 
+	SelectMissesInBlock = `SELECT ticket_hash FROM misses WHERE block_hash = $1;`
+
 	// Index
 	IndexMissesTableOnHashes = `CREATE UNIQUE INDEX uix_misses_hashes_index
 		ON misses(ticket_hash, block_hash);`

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -17,7 +17,7 @@ const (
 	insertTxRow        = insertTxRow0 + `RETURNING id;`
 	insertTxRowChecked = insertTxRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertTxRow        = insertTxRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
-		SET block_hash = $1, block_index = $2, tree = $3 RETURNING id;`
+		SET tx_hash = $8, block_hash = $1, RETURNING id;`
 	insertTxRowReturnId = `WITH ins AS (` +
 		insertTxRow0 +
 		`ON CONFLICT (tx_hash, block_hash) DO UPDATE
@@ -26,8 +26,8 @@ const (
 		)
 	SELECT id FROM ins
 	UNION  ALL
-	SELECT id FROM blocks
-	WHERE  tx_hash = $3 AND block_hash = $1
+	SELECT id FROM transactions
+	WHERE  tx_hash = $8 AND block_hash = $1
 	LIMIT  1;`
 
 	CreateTransactionTable = `CREATE TABLE IF NOT EXISTS transactions (

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -91,6 +91,13 @@ const (
 	// 	WHERE txs.id = $1;`
 	// RetrieveVoutValue = `SELECT vouts[$2].value FROM transactions WHERE id = $1;`
 
+	DeleteTxDuplicateRows = `DELETE FROM transactions
+	WHERE id IN (SELECT id FROM (
+			SELECT id, ROW_NUMBER()
+			OVER (partition BY tx_hash, block_hash ORDER BY id) AS rnum
+			FROM transactions) t
+		WHERE t.rnum > 1);`
+
 	RetrieveVoutDbIDs = `SELECT unnest(vout_db_ids) FROM transactions WHERE id = $1;`
 	RetrieveVoutDbID  = `SELECT vout_db_ids[$2] FROM transactions WHERE id = $1;`
 )

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -59,6 +59,8 @@ const (
 	SelectTxByHash       = `SELECT id, block_hash, block_index, tree FROM transactions WHERE tx_hash = $1;`
 	SelectTxsByBlockHash = `SELECT id, tx_hash, block_index, tree FROM transactions WHERE block_hash = $1;`
 
+	SelectTxIDHeightByHash = `SELECT id, block_height FROM transactions WHERE tx_hash = $1;`
+
 	SelectFullTxByHash = `SELECT id, block_hash, block_height, block_time, 
 		time, tx_type, version, tree, tx_hash, block_index, lock_time, expiry, 
 		size, spent, sent, fees, num_vin, vin_db_ids, num_vout, vout_db_ids 

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -14,10 +14,10 @@ const (
 		$10, $11, $12, $13, $14, $15,
 		$16, $17, $18,
 		$19, $20, $21) `
-	insertTxRow        = insertTxRow0 + `RETURNING id;`
-	insertTxRowChecked = insertTxRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
-	upsertTxRow        = insertTxRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
-		SET tx_hash = $8, block_hash = $1, RETURNING id;`
+	insertTxRow = insertTxRow0 + `RETURNING id;`
+	//insertTxRowChecked = insertTxRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
+	upsertTxRow = insertTxRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
+		SET tx_hash = $8, block_hash = $1 RETURNING id;`
 	insertTxRowReturnId = `WITH ins AS (` +
 		insertTxRow0 +
 		`ON CONFLICT (tx_hash, block_hash) DO UPDATE
@@ -110,7 +110,7 @@ const (
 
 func MakeTxInsertStatement(checked bool) string {
 	if checked {
-		return insertTxRowChecked
+		return upsertTxRow
 	}
 	return insertTxRow
 }

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -12,14 +12,12 @@ const (
 		block_hash, block_height, block_time, time,
 		tx_type, version, tree, tx_hash, block_index, 
 		lock_time, expiry, size, spent, sent, fees, 
-		num_vin, vins, vin_db_ids,
-		num_vout, vouts, vout_db_ids)
+		num_vin, vin_db_ids, num_vout, vout_db_ids)
 	VALUES (
 		$1, $2, $3, $4, 
 		$5, $6, $7, $8, $9,
 		$10, $11, $12, $13, $14, $15,
-		$16, $17, $18,
-		$19, $20, $21) `
+		$16, $17, $18, $19) `
 	insertTxRow = insertTxRow0 + `RETURNING id;`
 	//insertTxRowChecked = insertTxRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertTxRow = insertTxRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
@@ -55,10 +53,8 @@ const (
 		sent INT8,
 		fees INT8,
 		num_vin INT4,
-		vins JSONB,
 		vin_db_ids INT8[],
 		num_vout INT4,
-		vouts vout_t[],
 		vout_db_ids INT8[]
 	);`
 

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -1,5 +1,11 @@
 package internal
 
+import (
+	"fmt"
+
+	"github.com/decred/dcrd/blockchain/stake"
+)
+
 const (
 	// Insert
 	insertTxRow0 = `INSERT INTO transactions (
@@ -102,6 +108,10 @@ const (
 
 	RetrieveVoutDbIDs = `SELECT unnest(vout_db_ids) FROM transactions WHERE id = $1;`
 	RetrieveVoutDbID  = `SELECT vout_db_ids[$2] FROM transactions WHERE id = $1;`
+)
+
+var (
+	SelectAllRevokes = fmt.Sprintf(`SELECT id, tx_hash, block_height, vin_db_ids[0] FROM transactions WHERE tx_type = %d;`, stake.TxTypeSSRtx)
 )
 
 // func makeTxInsertStatement(voutDbIDs, vinDbIDs []uint64, vouts []*dbtypes.Vout, checked bool) string {

--- a/db/dcrpg/internal/txstmts.go
+++ b/db/dcrpg/internal/txstmts.go
@@ -23,7 +23,7 @@ const (
 	insertTxRow = insertTxRow0 + `RETURNING id;`
 	//insertTxRowChecked = insertTxRow0 + `ON CONFLICT (tx_hash, block_hash) DO NOTHING RETURNING id;`
 	upsertTxRow = insertTxRow0 + `ON CONFLICT (tx_hash, block_hash) DO UPDATE 
-		SET tx_hash = $8, block_hash = $1 RETURNING id;`
+		SET block_height = $2 RETURNING id;`
 	insertTxRowReturnId = `WITH ins AS (` +
 		insertTxRow0 +
 		`ON CONFLICT (tx_hash, block_hash) DO UPDATE

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -46,7 +46,7 @@ const (
 	DeindexVinTableOnPrevOuts = `DROP INDEX uix_vin_prevout;`
 
 	SelectVinIDsALL = `SELECT id FROM vins;`
-	CountRow        = `SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='vins';`
+	CountVinsRows   = `SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='vins';`
 
 	SelectSpendingTxsByPrevTx = `SELECT id, tx_hash, tx_index, prev_tx_index FROM vins WHERE prev_tx_hash=$1;`
 	SelectSpendingTxByPrevOut = `SELECT id, tx_hash, tx_index FROM vins 
@@ -120,9 +120,9 @@ const (
 		ON vouts(tx_hash, tx_index, tx_tree);`
 	DeindexVoutTableOnTxHashIdx = `DROP INDEX uix_vout_txhash_ind;`
 
-	IndexVoutTableOnTxHash = `CREATE INDEX uix_vout_txhash
-		ON vouts(tx_hash);`
-	DeindexVoutTableOnTxHash = `DROP INDEX uix_vout_txhash;`
+	// IndexVoutTableOnTxHash = `CREATE INDEX uix_vout_txhash
+	// 	ON vouts(tx_hash);`
+	// DeindexVoutTableOnTxHash = `DROP INDEX uix_vout_txhash;`
 
 	CreateVoutType = `CREATE TYPE vout_t AS (
 		value INT8,

--- a/db/dcrpg/internal/vinoutstmts.go
+++ b/db/dcrpg/internal/vinoutstmts.go
@@ -56,6 +56,7 @@ const (
 	SelectFundingOutpointByTxIn = `SELECT id, prev_tx_hash, prev_tx_index, prev_tx_tree FROM vins 
 		WHERE tx_hash=$1 AND tx_index=$2;`
 	SelectFundingOutpointByVinID = `SELECT prev_tx_hash, prev_tx_index, prev_tx_tree FROM vins WHERE id=$1;`
+	SelectFundingTxByVinID       = `SELECT prev_tx_hash FROM vins WHERE id=$1;`
 	SelectSpendingTxByVinID      = `SELECT tx_hash, tx_index, tx_tree FROM vins WHERE id=$1;`
 	SelectAllVinInfoByID         = `SELECT * FROM vins WHERE id=$1;`
 

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -368,6 +368,26 @@ func (pgb *ChainDB) DeindexAll() error {
 		log.Warn(err)
 		errAny = err
 	}
+	if err = DeindexVotesTableOnCandidate(pgb.db); err != nil {
+		log.Warn(err)
+		errAny = err
+	}
+	if err = DeindexVotesTableOnHash(pgb.db); err != nil {
+		log.Warn(err)
+		errAny = err
+	}
+	if err = DeindexVotesTableOnVoteVersion(pgb.db); err != nil {
+		log.Warn(err)
+		errAny = err
+	}
+	if err = DeindexTicketsTableOnHash(pgb.db); err != nil {
+		log.Warn(err)
+		errAny = err
+	}
+	if err = DeindexTicketsTableOnTxDbID(pgb.db); err != nil {
+		log.Warn(err)
+		errAny = err
+	}
 	return errAny
 }
 
@@ -399,6 +419,26 @@ func (pgb *ChainDB) IndexAll() error {
 	}
 	log.Infof("Indexing vouts table on tx hash...")
 	if err := IndexVoutTableOnTxHash(pgb.db); err != nil {
+		return err
+	}
+	log.Infof("Indexing votes table on candidate block...")
+	if err := IndexVotesTableOnCandidate(pgb.db); err != nil {
+		return err
+	}
+	log.Infof("Indexing votes table on vote hash...")
+	if err := IndexVotesTableOnHashes(pgb.db); err != nil {
+		return err
+	}
+	log.Infof("Indexing votes table on vote version...")
+	if err := IndexVotesTableOnVoteVersion(pgb.db); err != nil {
+		return err
+	}
+	log.Infof("Indexing tickets table on ticket hash...")
+	if err := IndexTicketsTableOnHashes(pgb.db); err != nil {
+		return err
+	}
+	log.Infof("Indexing tickets table on transaction id/indx...")
+	if err := IndexTicketsTableOnTxDbID(pgb.db); err != nil {
 		return err
 	}
 	// Not indexing the address table on vout ID or address here. See

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -322,7 +322,60 @@ func (pgb *ChainDB) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBloc
 	if pgb == nil {
 		return nil
 	}
-	_, _, err := pgb.StoreBlock(msgBlock, blockData.WinningTickets, true, true)
+	_, _, err := pgb.StoreBlock(msgBlock, blockData.WinningTickets, true, true, true)
+	return err
+}
+
+func (pgb *ChainDB) DeleteDuplicates() error {
+	var err error
+	// Remove duplicate vins
+	log.Info("Finding and removing duplicate vins entries...")
+	var numVinsRemoved int64
+	if numVinsRemoved, err = pgb.DeleteDuplicateVins(); err != nil {
+		return fmt.Errorf("dcrpg.DeleteDuplicateVins failed: %v", err)
+	}
+	log.Infof("Removed %d duplicate vins entries.", numVinsRemoved)
+
+	// Remove duplicate vouts
+	log.Info("Finding and removing duplicate vouts entries before indexing...")
+	var numVoutsRemoved int64
+	if numVoutsRemoved, err = pgb.DeleteDuplicateVouts(); err != nil {
+		return fmt.Errorf("dcrpg.DeleteDuplicateVouts failed: %v", err)
+	}
+	log.Infof("Removed %d duplicate vouts entries.", numVoutsRemoved)
+
+	// TODO: remove entries from addresses table that reference removed
+	// vins/vouts.
+
+	// Remove duplicate transactions
+	log.Info("Finding and removing duplicate transactions entries before indexing...")
+	var numTxnsRemoved int64
+	if numTxnsRemoved, err = pgb.DeleteDuplicateTxns(); err != nil {
+		return fmt.Errorf("dcrpg.DeleteDuplicateTxns failed: %v", err)
+	}
+	log.Infof("Removed %d duplicate transactions entries.", numTxnsRemoved)
+
+	// Remove duplicate tickets
+	log.Info("Finding and removing duplicate tickets entries before indexing...")
+	if numTxnsRemoved, err = pgb.DeleteDuplicateTickets(); err != nil {
+		return fmt.Errorf("dcrpg.DeleteDuplicateTickets failed: %v", err)
+	}
+	log.Infof("Removed %d duplicate tickets entries.", numTxnsRemoved)
+
+	// Remove duplicate votes
+	log.Info("Finding and removing duplicate votes entries before indexing...")
+	if numTxnsRemoved, err = pgb.DeleteDuplicateVotes(); err != nil {
+		return fmt.Errorf("dcrpg.DeleteDuplicateVotes failed: %v", err)
+	}
+	log.Infof("Removed %d duplicate votes entries.", numTxnsRemoved)
+
+	// Remove duplicate misses
+	log.Info("Finding and removing duplicate misses entries before indexing...")
+	if numTxnsRemoved, err = pgb.DeleteDuplicateMisses(); err != nil {
+		return fmt.Errorf("dcrpg.DeleteDuplicateMisses failed: %v", err)
+	}
+	log.Infof("Removed %d duplicate misses entries.", numTxnsRemoved)
+
 	return err
 }
 
@@ -480,6 +533,32 @@ func (pgb *ChainDB) IndexAll() error {
 	return IndexAddressTableOnTxHash(pgb.db)
 }
 
+// IndexTicketsTable creates the indexes on the tickets table on ticket hash and
+// tx DB ID columns, separately.
+func (pgb *ChainDB) IndexTicketsTable() error {
+	log.Infof("Indexing tickets table on ticket hash...")
+	if err := IndexTicketsTableOnHashes(pgb.db); err != nil {
+		return err
+	}
+	log.Infof("Indexing tickets table on transaction Db ID...")
+	return IndexTicketsTableOnTxDbID(pgb.db)
+}
+
+// DeindexTicketsTable drops the ticket hash and tx DB ID column indexes for the
+// tickets table.
+func (pgb *ChainDB) DeindexTicketsTable() error {
+	var errAny error
+	if err := DeindexTicketsTableOnHash(pgb.db); err != nil {
+		log.Warn(err)
+		errAny = err
+	}
+	if err := DeindexTicketsTableOnTxDbID(pgb.db); err != nil {
+		log.Warn(err)
+		errAny = err
+	}
+	return errAny
+}
+
 // IndexAddressTable creates the indexes on the address table on the vout ID and
 // address columns, separately.
 func (pgb *ChainDB) IndexAddressTable() error {
@@ -521,7 +600,7 @@ func (pgb *ChainDB) ExistsIndexAddressesVoutIDAddress() (bool, error) {
 // StoreBlock processes the input wire.MsgBlock, and saves to the data tables.
 // The number of vins, and vouts stored are also returned.
 func (pgb *ChainDB) StoreBlock(msgBlock *wire.MsgBlock, winningTickets []string,
-	isValid, updateAddressesSpendingInfo bool) (numVins int64, numVouts int64, err error) {
+	isValid, updateAddressesSpendingInfo, updateTicketsSpendingInfo bool) (numVins int64, numVouts int64, err error) {
 	// Convert the wire.MsgBlock to a dbtypes.Block
 	dbBlock := dbtypes.MsgBlockToDBBlock(msgBlock, pgb.chainParams)
 
@@ -554,14 +633,16 @@ func (pgb *ChainDB) StoreBlock(msgBlock *wire.MsgBlock, winningTickets []string,
 	resChanReg := make(chan storeTxnsResult)
 	go func() {
 		resChanReg <- pgb.storeTxns(MsgBlockPG, wire.TxTreeRegular,
-			pgb.chainParams, &dbBlock.TxDbIDs, updateAddressesSpendingInfo)
+			pgb.chainParams, &dbBlock.TxDbIDs, updateAddressesSpendingInfo,
+			updateTicketsSpendingInfo)
 	}()
 
 	// stake transactions
 	resChanStake := make(chan storeTxnsResult)
 	go func() {
 		resChanStake <- pgb.storeTxns(MsgBlockPG, wire.TxTreeStake,
-			pgb.chainParams, &dbBlock.STxDbIDs, updateAddressesSpendingInfo)
+			pgb.chainParams, &dbBlock.STxDbIDs, updateAddressesSpendingInfo,
+			updateTicketsSpendingInfo)
 	}()
 
 	errReg := <-resChanReg
@@ -651,7 +732,7 @@ type MsgBlockPG struct {
 
 func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 	chainParams *chaincfg.Params, TxDbIDs *[]uint64,
-	updateAddressesSpendingInfo bool) storeTxnsResult {
+	updateAddressesSpendingInfo, updateTicketsSpendingInfo bool) storeTxnsResult {
 	// For the given block, transaction tree, and network, extract the
 	// transactions, vins, and vouts.
 	dbTransactions, dbTxVouts, dbTxVins := dbtypes.ExtractBlockTransactions(
@@ -715,15 +796,39 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 		}
 
 		// Votes
-		_, _, err = InsertVotes(pgb.db, dbTransactions, msgBlock, pgb.dupChecks)
+		voteDbIDs, _, spentTicketHashes, _, err := InsertVotes(pgb.db,
+			dbTransactions, msgBlock, pgb.dupChecks)
 		if err != nil && err != sql.ErrNoRows {
 			log.Error("InsertVotes:", err)
 			txRes.err = err
 			return txRes
 		}
+
+		if updateTicketsSpendingInfo {
+			// To update spending info in tickets table, get the spent tickets' DB
+			// row IDs and block heights.
+			ticketDbIDs := make([]uint64, len(spentTicketHashes))
+			blockHeights := make([]int64, len(spentTicketHashes))
+			spendTypes := make([]TicketSpendType, len(spentTicketHashes))
+			for iv := range spentTicketHashes {
+				spendTypes[iv] = TicketVoted
+				blockHeights[iv] = int64(msgBlock.Header.Height) /* voteDbTxns[iv].BlockHeight */
+				ticketDbIDs[iv], _, err =
+					RetrieveTicketIDHeightByHash(pgb.db, spentTicketHashes[iv])
+				if err != nil {
+					log.Error("RetrieveTxIDHeightByHash:", err)
+					txRes.err = err
+					return txRes
+				}
+			}
+
+			// Update tickets table with spending info from new votes
+			_, err = SetSpendingForTickets(pgb.db, ticketDbIDs, voteDbIDs, blockHeights, spendTypes)
+			if err != nil {
+				log.Warn("SetSpendingForTickets:", err)
+			}
+		}
 	}
-	// TODO: update spending info of tickets given votes (redundant with
-	// spending info in addresses table)
 
 	// Store tx Db IDs as funding tx in AddressRows and rearrange
 	dbAddressRowsFlat := make([]*dbtypes.AddressRow, 0, totalAddressRows)
@@ -902,4 +1007,39 @@ func (pgb *ChainDB) UpdateSpendingInfoInAllAddresses() (int64, error) {
 	}
 
 	return numAddresses, err
+}
+
+// UpdateSpendingInfoInAllTickets reviews all votes and revokes (TODO: expires)
+// and sets this spending info in the tickets table.
+func (pgb *ChainDB) UpdateSpendingInfoInAllTickets() (int64, error) {
+	// Get the full list of votes (DB IDs and heights), and spent ticket hashes
+	allVotesDbIDs, allVotesHeights, allSpentTicketHashes, err :=
+		RetrieveAllVotesDbIDsHeightsTicketHashes(pgb.db)
+	if err != nil {
+		log.Errorf("RetrieveAllVinDbIDs: %v", err)
+		return 0, err
+	}
+
+	// To update spending info in tickets table, get the spent tickets' DB
+	// row IDs and block heights.
+	spendTypes := make([]TicketSpendType, len(allSpentTicketHashes))
+	for iv := range allSpentTicketHashes {
+		spendTypes[iv] = TicketVoted
+	}
+
+	var ticketDbIDs []uint64
+	ticketDbIDs, err = RetrieveTicketIDsByHashes(pgb.db, allSpentTicketHashes)
+	if err != nil {
+		return 0, fmt.Errorf("RetrieveTicketIDsByHashes: %v", err)
+	}
+
+	// Update tickets table with spending info from new votes\
+	var totalTicketsUpdated int64
+	totalTicketsUpdated, err = SetSpendingForTickets(pgb.db, ticketDbIDs,
+		allVotesDbIDs, allVotesHeights, spendTypes)
+	if err != nil {
+		log.Warn("SetSpendingForTickets:", err)
+	}
+
+	return totalTicketsUpdated, err
 }

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -417,6 +417,30 @@ func (pgb *ChainDB) DeleteDuplicates() error {
 	// TODO: remove entries from addresses table that reference removed
 	// vins/vouts.
 
+	return err
+}
+
+func (pgb *ChainDB) DeleteDuplicatesRecovery() error {
+	var err error
+	// Remove duplicate vins
+	log.Info("Finding and removing duplicate vins entries...")
+	var numVinsRemoved int64
+	if numVinsRemoved, err = pgb.DeleteDuplicateVins(); err != nil {
+		return fmt.Errorf("dcrpg.DeleteDuplicateVins failed: %v", err)
+	}
+	log.Infof("Removed %d duplicate vins entries.", numVinsRemoved)
+
+	// Remove duplicate vouts
+	log.Info("Finding and removing duplicate vouts entries before indexing...")
+	var numVoutsRemoved int64
+	if numVoutsRemoved, err = pgb.DeleteDuplicateVouts(); err != nil {
+		return fmt.Errorf("dcrpg.DeleteDuplicateVouts failed: %v", err)
+	}
+	log.Infof("Removed %d duplicate vouts entries.", numVoutsRemoved)
+
+	// TODO: remove entries from addresses table that reference removed
+	// vins/vouts.
+
 	// Remove duplicate transactions
 	log.Info("Finding and removing duplicate transactions entries before indexing...")
 	var numTxnsRemoved int64

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -708,7 +708,6 @@ func (pgb *ChainDB) StoreBlock(msgBlock *wire.MsgBlock, winningTickets []string,
 			return
 		}
 		winners = tpi.Winners
-		// can also access tpi.Expires
 	}
 
 	// Wrap the message block

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -577,6 +577,8 @@ func (pgb *ChainDB) storeTxns(msgBlock *wire.MsgBlock, txTree int8,
 		return txRes
 	}
 
+	// TODO: insert tickets (w/o spending info), insert votes, update spending info of tickets given votes
+
 	// Store tx Db IDs as funding tx in AddressRows and rearrange
 	dbAddressRowsFlat := make([]*dbtypes.AddressRow, 0, totalAddressRows)
 	for it, txDbID := range *TxDbIDs {

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -326,6 +326,14 @@ func (pgb *ChainDB) Store(blockData *blockdata.BlockData, msgBlock *wire.MsgBloc
 	return err
 }
 
+func (pgb *ChainDB) DeleteDuplicateVins() (int64, error) {
+	return DeleteDuplicateVins(pgb.db)
+}
+
+func (pgb *ChainDB) DeleteDuplicateVouts() (int64, error) {
+	return DeleteDuplicateVouts(pgb.db)
+}
+
 // DeindexAll drops all of the indexes in all tables
 func (pgb *ChainDB) DeindexAll() error {
 	var err, errAny error
@@ -353,10 +361,10 @@ func (pgb *ChainDB) DeindexAll() error {
 		log.Warn(err)
 		errAny = err
 	}
-	if err = DeindexVoutTableOnTxHash(pgb.db); err != nil {
-		log.Warn(err)
-		errAny = err
-	}
+	// if err = DeindexVoutTableOnTxHash(pgb.db); err != nil {
+	// 	log.Warn(err)
+	// 	errAny = err
+	// }
 	if err = DeindexAddressTableOnAddress(pgb.db); err != nil {
 		log.Warn(err)
 		errAny = err
@@ -422,10 +430,10 @@ func (pgb *ChainDB) IndexAll() error {
 	if err := IndexVoutTableOnTxHashIdx(pgb.db); err != nil {
 		return err
 	}
-	log.Infof("Indexing vouts table on tx hash...")
-	if err := IndexVoutTableOnTxHash(pgb.db); err != nil {
-		return err
-	}
+	// log.Infof("Indexing vouts table on tx hash...")
+	// if err := IndexVoutTableOnTxHash(pgb.db); err != nil {
+	// 	return err
+	// }
 	log.Infof("Indexing votes table on candidate block...")
 	if err := IndexVotesTableOnCandidate(pgb.db); err != nil {
 		return err
@@ -692,7 +700,7 @@ func (pgb *ChainDB) storeTxns(msgBlock *MsgBlockPG, txTree int8,
 	}
 
 	// Insert each new AddressRow, absent spending fields
-	_, err = InsertAddressOuts(pgb.db, dbAddressRowsFlat)
+	_, err = InsertAddressOuts(pgb.db, dbAddressRowsFlat, pgb.dupChecks)
 	if err != nil {
 		log.Error("InsertAddressOuts:", err)
 		txRes.err = err

--- a/db/dcrpg/pgblockchain_test.go
+++ b/db/dcrpg/pgblockchain_test.go
@@ -30,11 +30,7 @@ func openDB() (func() error, error) {
 	if db != nil {
 		cleanUp = db.Close
 	}
-	if err != nil {
-		return cleanUp, err
-	}
-
-	return cleanUp, db.SetupTables()
+	return cleanUp, err
 }
 
 func TestMain(m *testing.M) {

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -899,12 +899,10 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx, txDbIDs []uint64, msgBlock *w
 
 	// Choose only SSGen
 	var voteTx []*dbtypes.Tx
-	var voteDbIDs []uint64
 	var voteMsgTxs []*wire.MsgTx
 	for i, tx := range dbTxns {
 		if tx.TxType == int16(stake.TxTypeSSGen) {
 			voteTx = append(voteTx, tx)
-			voteDbIDs = append(voteDbIDs, txDbIDs[i])
 			voteMsgTxs = append(voteMsgTxs, msgTxs[i])
 		}
 	}

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -973,7 +973,7 @@ func InsertTxns(db *sql.DB, dbTxns []*dbtypes.Tx, checked bool) ([]uint64, error
 			tx.TxType, tx.Version, tx.Tree, tx.TxID, tx.BlockIndex,
 			tx.Locktime, tx.Expiry, tx.Size, tx.Spent, tx.Sent, tx.Fees,
 			tx.NumVin, tx.Vins, dbtypes.UInt64Array(tx.VinDbIds),
-			tx.NumVout, pq.Array(tx.Vouts), dbtypes.UInt64Array(tx.VoutDbIds)).Scan(&id)
+			tx.NumVout, pq.Array([]*dbtypes.Vout{}), dbtypes.UInt64Array(tx.VoutDbIds)).Scan(&id)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				continue

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -1322,7 +1322,7 @@ func InsertTickets(db *sql.DB, dbTxns []*dbtypes.Tx, txDbIDs []uint64, checked b
 
 		price := dcrutil.Amount(tx.Vouts[0].Value).ToCoin()
 		fee := dcrutil.Amount(tx.Fees).ToCoin()
-		isSplit := len(tx.Vins) > 1
+		isSplit := tx.NumVin > 1
 
 		var id uint64
 		err := stmt.QueryRow(
@@ -1510,8 +1510,8 @@ func InsertTx(db *sql.DB, dbTx *dbtypes.Tx, checked bool) (uint64, error) {
 		dbTx.BlockHash, dbTx.BlockHeight, dbTx.BlockTime, dbTx.Time,
 		dbTx.TxType, dbTx.Version, dbTx.Tree, dbTx.TxID, dbTx.BlockIndex,
 		dbTx.Locktime, dbTx.Expiry, dbTx.Size, dbTx.Spent, dbTx.Sent, dbTx.Fees,
-		dbTx.NumVin, dbTx.Vins, dbtypes.UInt64Array(dbTx.VinDbIds),
-		dbTx.NumVout, pq.Array(dbTx.Vouts), dbtypes.UInt64Array(dbTx.VoutDbIds)).Scan(&id)
+		dbTx.NumVin, dbtypes.UInt64Array(dbTx.VinDbIds),
+		dbTx.NumVout, dbtypes.UInt64Array(dbTx.VoutDbIds)).Scan(&id)
 	return id, err
 }
 
@@ -1535,8 +1535,8 @@ func InsertTxns(db *sql.DB, dbTxns []*dbtypes.Tx, checked bool) ([]uint64, error
 			tx.BlockHash, tx.BlockHeight, tx.BlockTime, tx.Time,
 			tx.TxType, tx.Version, tx.Tree, tx.TxID, tx.BlockIndex,
 			tx.Locktime, tx.Expiry, tx.Size, tx.Spent, tx.Sent, tx.Fees,
-			tx.NumVin, tx.Vins, dbtypes.UInt64Array(tx.VinDbIds),
-			tx.NumVout, pq.Array([]*dbtypes.Vout{}), dbtypes.UInt64Array(tx.VoutDbIds)).Scan(&id)
+			tx.NumVin, dbtypes.UInt64Array(tx.VinDbIds),
+			tx.NumVout, dbtypes.UInt64Array(tx.VoutDbIds)).Scan(&id)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				continue

--- a/db/dcrpg/queries.go
+++ b/db/dcrpg/queries.go
@@ -18,6 +18,15 @@ import (
 	"github.com/lib/pq"
 )
 
+type TicketSpendType int16
+
+const (
+	TicketExpired TicketSpendType = iota - 1
+	TicketLive
+	TicketVoted
+	TicketRevoked
+)
+
 func ExistsIndex(db *sql.DB, indexName string) (exists bool, err error) {
 	err = db.QueryRow(internal.IndexExists, indexName, "public").Scan(&exists)
 	return
@@ -36,6 +45,138 @@ func RetrievePkScriptByID(db *sql.DB, id uint64) (pkScript []byte, err error) {
 func RetrieveVoutIDByOutpoint(db *sql.DB, txHash string, voutIndex uint32) (id uint64, err error) {
 	err = db.QueryRow(internal.SelectVoutIDByOutpoint, txHash, voutIndex).Scan(&id)
 	return
+}
+
+func RetrieveAllVotesDbIDsHeightsTicketHashes(db *sql.DB) (ids []uint64, heights []int64,
+	ticketHashes []string, err error) {
+	rows, err := db.Query(internal.SelectAllVoteDbIDsHeightsTicketHashes)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	defer func() {
+		if e := rows.Close(); e != nil {
+			log.Errorf("Close of Query failed: %v", e)
+		}
+	}()
+
+	for rows.Next() {
+		var id uint64
+		var height int64
+		var ticketHash string
+		err = rows.Scan(&id, &height, &ticketHash)
+		if err != nil {
+			break
+		}
+
+		ids = append(ids, id)
+		heights = append(heights, height)
+		ticketHashes = append(ticketHashes, ticketHash)
+	}
+	return
+}
+
+func RetrieveTicketIDHeightByHash(db *sql.DB, ticketHash string) (id uint64, blockHeight int64, err error) {
+	err = db.QueryRow(internal.SelectTicketIDHeightByHash, ticketHash).Scan(&id, &blockHeight)
+	return
+}
+
+func RetrieveTicketIDByHash(db *sql.DB, ticketHash string) (id uint64, err error) {
+	err = db.QueryRow(internal.SelectTicketIDByHash, ticketHash).Scan(&id)
+	return
+}
+
+func RetrieveTicketIDsByHashes(db *sql.DB, ticketHashes []string) (ids []uint64, err error) {
+	dbtx, err := db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("unable to begin database transaction: %v", err)
+	}
+
+	stmt, err := dbtx.Prepare(internal.SelectTicketIDByHash)
+	if err != nil {
+		log.Errorf("Tickets SELECT prepare: %v", err)
+		_ = stmt.Close()
+		_ = dbtx.Rollback() // try, but we want the Prepare error back
+		return nil, err
+	}
+
+	ids = make([]uint64, 0, len(ticketHashes))
+	for ih := range ticketHashes {
+		var id uint64
+		err = stmt.QueryRow(ticketHashes[ih]).Scan(&id)
+		if err != nil {
+			_ = stmt.Close() // try, but we want the QueryRow error back
+			if errRoll := dbtx.Rollback(); errRoll != nil {
+				log.Errorf("Rollback failed: %v", errRoll)
+			}
+			return ids, fmt.Errorf("Tickets SELECT exec failed: %v", err)
+		}
+		ids = append(ids, id)
+	}
+
+	// Close prepared statement. Ignore errors as we'll Commit regardless.
+	_ = stmt.Close()
+
+	return ids, dbtx.Commit()
+}
+
+func SetSpendingForTickets(db *sql.DB, ticketDbIDs, spendDbIDs []uint64,
+	blockHeights []int64, spendTypes []TicketSpendType) (int64, error) {
+	dbtx, err := db.Begin()
+	if err != nil {
+		return 0, fmt.Errorf(`unable to begin database transaction: %v`, err)
+	}
+
+	var stmt *sql.Stmt
+	stmt, err = dbtx.Prepare(internal.SetTicketSpendingInfoForTicketDbID)
+	if err != nil {
+		// Already up a creek. Just return error from Prepare.
+		_ = dbtx.Rollback()
+		return 0, fmt.Errorf("tickets SELECT prepare failed: %v", err)
+	}
+
+	var totalTicketsUpdated int64
+	rowsAffected := make([]int64, len(ticketDbIDs))
+	for i, ticketDbID := range ticketDbIDs {
+		rowsAffected[i], err = sqlExecStmt(stmt, "failed to set ticket spending info: ",
+			ticketDbID, blockHeights[i], spendDbIDs[i], spendTypes[i])
+		if err != nil {
+			_ = stmt.Close()
+			return 0, dbtx.Rollback()
+		}
+		totalTicketsUpdated += rowsAffected[i]
+		if rowsAffected[i] != 1 {
+			log.Warnf("Updated spending info for %d tickets, expecting just 1!",
+				rowsAffected[i])
+		}
+	}
+
+	_ = stmt.Close()
+
+	return totalTicketsUpdated, dbtx.Commit()
+}
+
+func setSpendingForTickets(dbtx *sql.Tx, ticketDbIDs, spendDbIDs []uint64,
+	blockHeights []int64, spendTypes []TicketSpendType) error {
+	stmt, err := dbtx.Prepare(internal.SetTicketSpendingInfoForTicketDbID)
+	if err != nil {
+		return fmt.Errorf("tickets SELECT prepare failed: %v", err)
+	}
+
+	rowsAffected := make([]int64, len(ticketDbIDs))
+	for i, ticketDbID := range ticketDbIDs {
+		rowsAffected[i], err = sqlExecStmt(stmt, "failed to set ticket spending info: ",
+			ticketDbID, blockHeights[i], spendDbIDs[i], spendTypes[i])
+		if err != nil {
+			_ = stmt.Close()
+			return err
+		}
+		if rowsAffected[i] != 1 {
+			log.Warnf("Updated spending info for %d tickets, expecting just 1!",
+				rowsAffected[i])
+		}
+	}
+
+	return stmt.Close()
 }
 
 func SetSpendingForVinDbIDs(db *sql.DB, vinDbIDs []uint64) ([]int64, int64, error) {
@@ -299,6 +440,23 @@ func DeleteDuplicateMisses(db *sql.DB) (int64, error) {
 
 func sqlExec(db *sql.DB, stmt, execErrPrefix string, args ...interface{}) (int64, error) {
 	res, err := db.Exec(stmt, args...)
+	if err != nil {
+		return 0, fmt.Errorf(execErrPrefix + err.Error())
+	}
+	if res == nil {
+		return 0, nil
+	}
+
+	var N int64
+	N, err = res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf(`error in RowsAffected: %v`, err)
+	}
+	return N, err
+}
+
+func sqlExecStmt(stmt *sql.Stmt, execErrPrefix string, args ...interface{}) (int64, error) {
+	res, err := stmt.Exec(args...)
 	if err != nil {
 		return 0, fmt.Errorf(execErrPrefix + err.Error())
 	}
@@ -625,6 +783,11 @@ func RetrieveFullTxByHash(db *sql.DB, txHash string) (id uint64,
 
 func RetrieveTxByHash(db *sql.DB, txHash string) (id uint64, blockHash string, blockInd uint32, tree int8, err error) {
 	err = db.QueryRow(internal.SelectTxByHash, txHash).Scan(&id, &blockHash, &blockInd, &tree)
+	return
+}
+
+func RetrieveTxIDHeightByHash(db *sql.DB, txHash string) (id uint64, blockHeight int64, err error) {
+	err = db.QueryRow(internal.SelectTxIDHeightByHash, txHash).Scan(&id, &blockHeight)
 	return
 }
 
@@ -977,7 +1140,8 @@ func InsertTickets(db *sql.DB, dbTxns []*dbtypes.Tx, txDbIDs []uint64, checked b
 		var id uint64
 		err := stmt.QueryRow(
 			tx.TxID, tx.BlockHash, tx.BlockHeight, ticketDbIDs[i],
-			stakesubmissionAddress, isMultisig, isSplit, tx.NumVin, price, fee).Scan(&id)
+			stakesubmissionAddress, isMultisig, isSplit, tx.NumVin,
+			price, fee, TicketLive).Scan(&id)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				continue
@@ -1010,54 +1174,57 @@ func InsertTickets(db *sql.DB, dbTxns []*dbtypes.Tx, txDbIDs []uint64, checked b
 //
 // Outputs are slices of DB row IDs for the votes and misses, and an error.
 func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx,
-	msgBlock *MsgBlockPG, checked bool) ([]uint64, []uint64, error) {
+	msgBlock *MsgBlockPG, checked bool) ([]uint64, []*dbtypes.Tx, []string, []uint64, error) {
 	// Choose only SSGen txns
 	msgTxs := msgBlock.STransactions
-	var voteTx []*dbtypes.Tx
+	var voteTxs []*dbtypes.Tx
 	var voteMsgTxs []*wire.MsgTx
 	for i, tx := range dbTxns {
 		if tx.TxType == int16(stake.TxTypeSSGen) {
-			voteTx = append(voteTx, tx)
+			voteTxs = append(voteTxs, tx)
 			voteMsgTxs = append(voteMsgTxs, msgTxs[i])
 			if tx.TxID != msgTxs[i].TxHash().String() {
-				return nil, nil, fmt.Errorf("txid of dbtypes.Tx does not match that of msgTx")
+				return nil, nil, nil, nil, fmt.Errorf("txid of dbtypes.Tx does not match that of msgTx")
 			}
 		}
 	}
 
-	if len(voteTx) == 0 {
-		return nil, nil, nil
+	if len(voteTxs) == 0 {
+		return nil, nil, nil, nil, nil
 	}
 
 	// Start DB transaction and prepare vote insert statement
 	dbtx, err := db.Begin()
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to begin database transaction: %v", err)
+		return nil, nil, nil, nil, fmt.Errorf("unable to begin database transaction: %v", err)
 	}
 
 	stmt, err := dbtx.Prepare(internal.MakeVoteInsertStatement(checked))
 	if err != nil {
 		log.Errorf("Votes INSERT prepare: %v", err)
 		_ = dbtx.Rollback() // try, but we want the Prepare error back
-		return nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	// Insert each vote, and build list of missed votes equal to
 	// setdiff(Validators, votes).
 	candidateBlockHash := msgBlock.Header.PrevBlock.String()
-	ids := make([]uint64, 0, len(voteTx))
+	ids := make([]uint64, 0, len(voteTxs))
+	spentTicketHashes := make([]string, 0, len(voteTxs))
 	misses := make([]string, len(msgBlock.Validators))
 	copy(misses, msgBlock.Validators)
-	for i, tx := range voteTx {
+	for i, tx := range voteTxs {
 		msgTx := voteMsgTxs[i]
 		voteVersion := stake.SSGenVersion(msgTx)
 		validBlock, voteBits, err := txhelpers.SSGenVoteBlockValid(msgTx)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 
 		stakeSubmissionAmount := dcrutil.Amount(msgTx.TxIn[1].ValueIn).ToCoin()
 		stakeSubmissionTxHash := msgTx.TxIn[1].PreviousOutPoint.Hash.String()
+		spentTicketHashes = append(spentTicketHashes, stakeSubmissionTxHash)
+
 		voteReward := dcrutil.Amount(msgTx.TxIn[0].ValueIn).ToCoin()
 
 		// delete spent ticket from missed list
@@ -1082,7 +1249,7 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx,
 			if errRoll := dbtx.Rollback(); errRoll != nil {
 				log.Errorf("Rollback failed: %v", errRoll)
 			}
-			return nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 		ids = append(ids, id)
 	}
@@ -1092,7 +1259,7 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx,
 
 	if len(ids)+len(misses) != 5 {
 		fmt.Println(misses)
-		fmt.Println(voteTx)
+		fmt.Println(voteTxs)
 		_ = dbtx.Rollback()
 		panic(fmt.Sprintf("votes (%d) + misses (%d) != 5", len(ids), len(misses)))
 	}
@@ -1104,11 +1271,11 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx,
 		if err != nil {
 			log.Errorf("Miss INSERT prepare: %v", err)
 			_ = dbtx.Rollback() // try, but we want the Prepare error back
-			return nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 
 		blockHash := msgBlock.BlockHash().String()
-		idsMisses = make([]uint64, 0, len(voteTx))
+		idsMisses = make([]uint64, 0, len(voteTxs))
 		for i := range misses {
 			var id uint64
 			err = stmtMissed.QueryRow(
@@ -1122,14 +1289,14 @@ func InsertVotes(db *sql.DB, dbTxns []*dbtypes.Tx,
 				if errRoll := dbtx.Rollback(); errRoll != nil {
 					log.Errorf("Rollback failed: %v", errRoll)
 				}
-				return nil, nil, err
+				return nil, nil, nil, nil, err
 			}
 			idsMisses = append(idsMisses, id)
 		}
 		_ = stmtMissed.Close()
 	}
 
-	return ids, idsMisses, dbtx.Commit()
+	return ids, voteTxs, spentTicketHashes, idsMisses, dbtx.Commit()
 }
 
 func InsertTx(db *sql.DB, dbTx *dbtypes.Tx, checked bool) (uint64, error) {

--- a/db/dcrpg/sync.go
+++ b/db/dcrpg/sync.go
@@ -160,6 +160,11 @@ func (db *ChainDB) SyncChainDB(client *rpcclient.Client, quit chan struct{},
 				"stake DB height %d.", ib, db.stakeDB.Height())
 			waitSec := math.Max(5, math.Min(30.0, float64(blocksBehind)/500))
 			time.Sleep(time.Duration(waitSec) * time.Second)
+
+			if blocksBehind <= int64(db.stakeDB.Height()) {
+				log.Infof("Rescan halted waiting for stakedb to advance.")
+				return ib - 1, nil
+			}
 		}
 
 		var numVins, numVouts int64

--- a/db/dcrpg/sync.go
+++ b/db/dcrpg/sync.go
@@ -185,9 +185,30 @@ func (db *ChainDB) SyncChainDB(client *rpcclient.Client, quit chan struct{},
 	speedReport()
 
 	if reindexing || newIndexes {
+		// Remove duplicate vins
+		log.Info("Finding and removing duplicate vins entries before indexing...")
+		var numVinsRemoved int64
+		if numVinsRemoved, err = db.DeleteDuplicateVins(); err != nil {
+			return 0, fmt.Errorf("dcrpg.DeleteDuplicateVins failed: %v", err)
+		}
+		log.Infof("Removed %d duplicate vins entries.", numVinsRemoved)
+
+		// Remove duplicate vouts
+		log.Info("Finding and removing duplicate vouts entries before indexing...")
+		var numVoutsRemoved int64
+		if numVoutsRemoved, err = db.DeleteDuplicateVouts(); err != nil {
+			return 0, fmt.Errorf("dcrpg.DeleteDuplicateVouts failed: %v", err)
+		}
+		log.Infof("Removed %d duplicate vouts entries.", numVoutsRemoved)
+
+		// TODO: remove entries from addresses table that reference removed
+		// vins/vouts.
+
+		// Create indexes
 		if err = db.IndexAll(); err != nil {
 			return nodeHeight, fmt.Errorf("IndexAll failed: %v", err)
 		}
+		// Only reindex address table here if we do not do it below
 		if !updateAllAddresses {
 			err = db.IndexAddressTable()
 		}

--- a/db/dcrpg/sync.go
+++ b/db/dcrpg/sync.go
@@ -150,11 +150,15 @@ func (db *ChainDB) SyncChainDB(client *rpcclient.Client, quit chan struct{},
 			default:
 			}
 
+			// stakeDB is not locked between Height() and PoolInfo() so there is
+			// a data race. Get the height first to avoid resulting errors.
+			blocksBehind := ib - int64(db.stakeDB.Height())
+
 			if tpi, ok := db.stakeDB.PoolInfo(*blockHash); ok {
 				winners = tpi.Winners
 				break
 			}
-			blocksBehind := ib - int64(db.stakeDB.Height())
+
 			if blocksBehind <= 0 {
 				return ib - 1, fmt.Errorf("stakeDB.PoolInfo failed.")
 			}

--- a/db/dcrpg/sync.go
+++ b/db/dcrpg/sync.go
@@ -163,7 +163,7 @@ func (db *ChainDB) SyncChainDB(client *rpcclient.Client, quit chan struct{},
 			waitSec := math.Max(5, math.Min(30.0, float64(blocksBehind)/500))
 			time.Sleep(time.Duration(waitSec) * time.Second)
 
-			if blocksBehind <= int64(db.stakeDB.Height()) {
+			if blocksBehind <= ib-int64(db.stakeDB.Height()) {
 				log.Infof("Rescan halted waiting for stakedb to advance.")
 				return ib - 1, nil
 			}

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -246,20 +246,20 @@ func DeindexBlockTableOnHash(db *sql.DB) (err error) {
 
 // Vouts table indexes
 
-func IndexVoutTableOnTxHash(db *sql.DB) (err error) {
-	_, err = db.Exec(internal.IndexVoutTableOnTxHash)
-	return
-}
+// func IndexVoutTableOnTxHash(db *sql.DB) (err error) {
+// 	_, err = db.Exec(internal.IndexVoutTableOnTxHash)
+// 	return
+// }
 
 func IndexVoutTableOnTxHashIdx(db *sql.DB) (err error) {
 	_, err = db.Exec(internal.IndexVoutTableOnTxHashIdx)
 	return
 }
 
-func DeindexVoutTableOnTxHash(db *sql.DB) (err error) {
-	_, err = db.Exec(internal.DeindexVoutTableOnTxHash)
-	return
-}
+// func DeindexVoutTableOnTxHash(db *sql.DB) (err error) {
+// 	_, err = db.Exec(internal.DeindexVoutTableOnTxHash)
+// 	return
+// }
 
 func DeindexVoutTableOnTxHashIdx(db *sql.DB) (err error) {
 	_, err = db.Exec(internal.DeindexVoutTableOnTxHashIdx)

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -21,6 +21,7 @@ var createTableStatements = map[string]string{
 	"addresses":    internal.CreateAddressTable,
 	"tickets":      internal.CreateTicketsTable,
 	"votes":        internal.CreateVotesTable,
+	"misses":       internal.CreateMissesTable,
 }
 
 var createTypeStatements = map[string]string{
@@ -348,5 +349,17 @@ func IndexTicketsTableOnTxDbID(db *sql.DB) (err error) {
 
 func DeindexTicketsTableOnTxDbID(db *sql.DB) (err error) {
 	_, err = db.Exec(internal.DeindexTicketsTableOnTxDbID)
+	return
+}
+
+// Missed votes table indexes
+
+func IndexMissesTableOnHashes(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.IndexMissesTableOnHashes)
+	return
+}
+
+func DeindexMissesTableOnHash(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.DeindexMissesTableOnHashes)
 	return
 }

--- a/db/dcrpg/tables.go
+++ b/db/dcrpg/tables.go
@@ -19,6 +19,8 @@ var createTableStatements = map[string]string{
 	"vouts":        internal.CreateVoutTable,
 	"block_chain":  internal.CreateBlockPrevNextTable,
 	"addresses":    internal.CreateAddressTable,
+	"tickets":      internal.CreateTicketsTable,
+	"votes":        internal.CreateVotesTable,
 }
 
 var createTypeStatements = map[string]string{
@@ -292,5 +294,59 @@ func IndexAddressTableOnTxHash(db *sql.DB) (err error) {
 
 func DeindexAddressTableOnTxHash(db *sql.DB) (err error) {
 	_, err = db.Exec(internal.DeindexAddressTableOnFundingTx)
+	return
+}
+
+// Votes table indexes
+
+func IndexVotesTableOnHashes(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.IndexVotesTableOnHashes)
+	return
+}
+
+func DeindexVotesTableOnHash(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.DeindexVotesTableOnHashes)
+	return
+}
+
+func IndexVotesTableOnCandidate(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.IndexVotesTableOnCandidate)
+	return
+}
+
+func DeindexVotesTableOnCandidate(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.DeindexVotesTableOnCandidate)
+	return
+}
+
+func IndexVotesTableOnVoteVersion(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.IndexVotesTableOnVoteVersion)
+	return
+}
+
+func DeindexVotesTableOnVoteVersion(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.DeindexVotesTableOnVoteVersion)
+	return
+}
+
+// Tickets table indexes
+
+func IndexTicketsTableOnHashes(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.IndexTicketsTableOnHashes)
+	return
+}
+
+func DeindexTicketsTableOnHash(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.DeindexTicketsTableOnHashes)
+	return
+}
+
+func IndexTicketsTableOnTxDbID(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.IndexTicketsTableOnTxDbID)
+	return
+}
+
+func DeindexTicketsTableOnTxDbID(db *sql.DB) (err error) {
+	_, err = db.Exec(internal.DeindexTicketsTableOnTxDbID)
 	return
 }

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1075,7 +1075,7 @@ func (db *wiredDB) GetExplorerTx(txid string) *explorer.TxInfo {
 			tx.Mature = "True"
 		} else {
 			tx.Mature = "False"
-			tx.TicketMaturity = int64(db.params.TicketMaturity)
+			tx.TicketInfo.TicketMaturity = int64(db.params.TicketMaturity)
 		}
 	}
 	if tx.Type == "Vote" {

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -97,7 +97,9 @@ func (db *wiredDB) NewStakeDBChainMonitor(quit chan struct{}, wg *sync.WaitGroup
 }
 
 func (db *wiredDB) ChargePoolInfoCache(startHeight int64) error {
-	//stakeDBHeight := db.sDB.Height()
+	if startHeight < 0 {
+		startHeight = 0
+	}
 	endHeight := db.GetStakeInfoHeight()
 	tpis, blockHashes, err := db.DB.RetrievePoolInfoRange(startHeight, endHeight)
 	if err != nil {

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -100,11 +100,16 @@ func (db *wiredDB) ChargePoolInfoCache(startHeight int64) error {
 	if startHeight < 0 {
 		startHeight = 0
 	}
-	endHeight := db.GetStakeInfoHeight()
+	endHeight, err := db.GetStakeInfoHeight()
+	if err != nil {
+		return err
+	}
 	tpis, blockHashes, err := db.DB.RetrievePoolInfoRange(startHeight, endHeight)
 	if err != nil {
 		return err
 	}
+	log.Debugf("Pre-loading pool info for %d blocks ([%d, %d]) into cache.",
+		len(tpis), startHeight, endHeight)
 	for i := range tpis {
 		hash, err := chainhash.NewHashFromStr(blockHashes[i])
 		if err != nil {

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -6,6 +6,7 @@ package dcrsqlite
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/btcsuite/btclog"
@@ -49,6 +50,7 @@ type DB struct {
 	dbStakeInfoHeight                                   int64
 	getPoolSQL, getPoolRangeSQL                         string
 	getPoolByHashSQL                                    string
+	getWinnersByHashSQL, getWinnersSQL                  string
 	getSDiffSQL, getSDiffRangeSQL                       string
 	getLatestBlockSQL                                   string
 	getBlockSQL, insertBlockSQL                         string
@@ -58,6 +60,7 @@ type DB struct {
 	getBestBlockHashSQL, getBestBlockHeightSQL          string
 	getLatestStakeInfoExtendedSQL                       string
 	getStakeInfoExtendedSQL, insertStakeInfoExtendedSQL string
+	getStakeInfoWinnersSQL                              string
 }
 
 // NewDB creates a new DB instance with pre-generated sql statements from an
@@ -71,11 +74,15 @@ func NewDB(db *sql.DB) (*DB, error) {
 	}
 
 	// Ticket pool queries
-	d.getPoolSQL = fmt.Sprintf(`select poolsize, poolval, poolavg from %s where height = ?`,
+	d.getPoolSQL = fmt.Sprintf(`select hash, poolsize, poolval, poolavg, winners from %s where height = ?`,
 		TableNameSummaries)
-	d.getPoolByHashSQL = fmt.Sprintf(`select poolsize, poolval, poolavg from %s where hash = ?`,
+	d.getPoolByHashSQL = fmt.Sprintf(`select height, poolsize, poolval, poolavg, winners from %s where hash = ?`,
 		TableNameSummaries)
-	d.getPoolRangeSQL = fmt.Sprintf(`select poolsize, poolval, poolavg from %s where height between ? and ?`,
+	d.getPoolRangeSQL = fmt.Sprintf(`select height, hash, poolsize, poolval, poolavg, winners from %s where height between ? and ?`,
+		TableNameSummaries)
+	d.getWinnersSQL = fmt.Sprintf(`select hash, winners from %s where height = ?`,
+		TableNameSummaries)
+	d.getWinnersByHashSQL = fmt.Sprintf(`select height, winners from %s where hash = ?`,
 		TableNameSummaries)
 
 	d.getSDiffSQL = fmt.Sprintf(`select sdiff from %s where height = ?`,
@@ -90,8 +97,8 @@ func NewDB(db *sql.DB) (*DB, error) {
 		TableNameSummaries)
 	d.insertBlockSQL = fmt.Sprintf(`
         INSERT OR REPLACE INTO %s(
-            height, size, hash, diff, sdiff, time, poolsize, poolval, poolavg
-        ) values(?, ?, ?, ?, ?, ?, ?, ?, ?)
+            height, size, hash, diff, sdiff, time, poolsize, poolval, poolavg, winners
+        ) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, TableNameSummaries)
 
 	d.getBlockSizeRangeSQL = fmt.Sprintf(`select size from %s where height between ? and ?`,
@@ -106,13 +113,15 @@ func NewDB(db *sql.DB) (*DB, error) {
 	// Stake info queries
 	d.getStakeInfoExtendedSQL = fmt.Sprintf(`select * from %s where height = ?`,
 		TableNameStakeInfo)
+	d.getStakeInfoWinnersSQL = fmt.Sprintf(`select winners from %s where height = ?`,
+		TableNameStakeInfo)
 	d.getLatestStakeInfoExtendedSQL = fmt.Sprintf(
 		`SELECT * FROM %s ORDER BY height DESC LIMIT 0, 1`, TableNameStakeInfo)
 	d.insertStakeInfoExtendedSQL = fmt.Sprintf(`
         INSERT OR REPLACE INTO %s(
             height, num_tickets, fee_min, fee_max, fee_mean, fee_med, fee_std,
-			sdiff, window_num, window_ind, pool_size, pool_val, pool_valavg
-        ) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			sdiff, window_num, window_ind, pool_size, pool_val, pool_valavg, winners
+        ) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `, TableNameStakeInfo)
 
 	var err error
@@ -146,7 +155,8 @@ func InitDB(dbInfo *DBInfo) (*DB, error) {
             time INTEGER,
             poolsize INTEGER,
             poolval FLOAT,
-            poolavg FLOAT
+			poolavg FLOAT,
+			winners TEXT
         );
         `, TableNameSummaries)
 
@@ -165,7 +175,8 @@ func InitDB(dbInfo *DBInfo) (*DB, error) {
             fee_min FLOAT, fee_max FLOAT, fee_mean FLOAT,
 			fee_med FLOAT, fee_std FLOAT,
 			sdiff FLOAT, window_num INTEGER, window_ind INTEGER,
-            pool_size INTEGER, pool_val FLOAT, pool_valavg FLOAT
+			pool_size INTEGER, pool_val FLOAT, pool_valavg FLOAT,
+			winners TEXT
         );
         `, TableNameStakeInfo)
 
@@ -215,7 +226,8 @@ func (db *DB) StoreBlockSummary(bd *apitypes.BlockDataBasic) error {
 
 	res, err := stmt.Exec(&bd.Height, &bd.Size, &bd.Hash,
 		&bd.Difficulty, &bd.StakeDiff, &bd.Time,
-		&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg)
+		&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg,
+		&bd.PoolInfo.Winners)
 	if err != nil {
 		return err
 	}
@@ -292,63 +304,97 @@ func (db *DB) GetStakeInfoHeight() (int64, error) {
 
 // RetrievePoolInfoRange returns an array of apitypes.TicketPoolInfo for block
 // range ind0 to ind1 and a non-nil error on success
-func (db *DB) RetrievePoolInfoRange(ind0, ind1 int64) ([]apitypes.TicketPoolInfo, error) {
+func (db *DB) RetrievePoolInfoRange(ind0, ind1 int64) ([]apitypes.TicketPoolInfo, []string, error) {
 	N := ind1 - ind0 + 1
 	if N == 0 {
-		return []apitypes.TicketPoolInfo{}, nil
+		return []apitypes.TicketPoolInfo{}, []string{}, nil
 	}
 	if N < 0 {
-		return nil, fmt.Errorf("Cannot retrieve pool info range (%d<%d)",
+		return nil, nil, fmt.Errorf("Cannot retrieve pool info range (%d<%d)",
 			ind1, ind0)
 	}
 	db.RLock()
 	if ind1 > db.dbSummaryHeight || ind0 < 0 {
 		defer db.RUnlock()
-		return nil, fmt.Errorf("Cannot retrieve pool info range [%d,%d], have height %d",
+		return nil, nil, fmt.Errorf("Cannot retrieve pool info range [%d,%d], have height %d",
 			ind1, ind0, db.dbSummaryHeight)
 	}
 	db.RUnlock()
 
 	tpis := make([]apitypes.TicketPoolInfo, 0, N)
+	hashes := make([]string, 0, N)
 
 	stmt, err := db.Prepare(db.getPoolRangeSQL)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer stmt.Close()
 
 	rows, err := stmt.Query(ind0, ind1)
 	if err != nil {
 		log.Errorf("Query failed: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 	defer rows.Close()
 
 	for rows.Next() {
 		var tpi apitypes.TicketPoolInfo
-		if err = rows.Scan(&tpi.Size, &tpi.Value, &tpi.ValAvg); err != nil {
+		var hash string
+		if err = rows.Scan(&tpi.Height, &hash, &tpi.Size, &tpi.Value, &tpi.ValAvg, &tpi.Winners); err != nil {
 			log.Errorf("Unable to scan for TicketPoolInfo fields: %v", err)
 		}
 		tpis = append(tpis, tpi)
+		hashes = append(hashes, hash)
 	}
 	if err = rows.Err(); err != nil {
 		log.Error(err)
 	}
 
-	return tpis, nil
+	return tpis, hashes, nil
 }
 
 // RetrievePoolInfo returns ticket pool info for block height ind
 func (db *DB) RetrievePoolInfo(ind int64) (*apitypes.TicketPoolInfo, error) {
-	tpi := new(apitypes.TicketPoolInfo)
-	err := db.QueryRow(db.getPoolSQL, ind).Scan(&tpi.Size, &tpi.Value, &tpi.ValAvg)
+	tpi := &apitypes.TicketPoolInfo{
+		Height: uint32(ind),
+	}
+	var hash string
+	err := db.QueryRow(db.getPoolSQL, ind).Scan(&hash, &tpi.Size,
+		&tpi.Value, &tpi.ValAvg, &tpi.Winners)
 	return tpi, err
+}
+
+// RetrieveWinners returns the winning ticket tx IDs drawn after connecting the
+// given block height (called to validate the block). The block hash
+// corresponding to the input block height is also returned.
+func (db *DB) RetrieveWinners(ind int64) ([]string, string, error) {
+	var hash, winners string
+	err := db.QueryRow(db.getWinnersSQL, ind).Scan(&hash, &winners)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return strings.Split(winners, ";"), hash, err
+}
+
+// RetrieveWinnersByHash returns the winning ticket tx IDs drawn after
+// connecting the block with the given hash. The block height corresponding to
+// the input block hash is also returned.
+func (db *DB) RetrieveWinnersByHash(hash string) ([]string, uint32, error) {
+	var winners string
+	var height uint32
+	err := db.QueryRow(db.getWinnersByHashSQL, hash).Scan(&height, &winners)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return strings.Split(winners, ";"), height, err
 }
 
 // RetrievePoolInfoByHash returns ticket pool info for blockhash hash
 func (db *DB) RetrievePoolInfoByHash(hash string) (*apitypes.TicketPoolInfo, error) {
 	tpi := new(apitypes.TicketPoolInfo)
-	err := db.QueryRow(db.getPoolByHashSQL, hash).Scan(&tpi.Size, &tpi.Value, &tpi.ValAvg)
+	err := db.QueryRow(db.getPoolByHashSQL, hash).Scan(&tpi.Height, &tpi.Size, &tpi.Value, &tpi.ValAvg, &tpi.Winners)
 	return tpi, err
 }
 
@@ -388,8 +434,10 @@ func (db *DB) RetrievePoolValAndSizeRange(ind0, ind1 int64) ([]float64, []float6
 	defer rows.Close()
 
 	for rows.Next() {
+		var height uint32
+		var hash, winners string
 		var pval, psize, pavg float64
-		if err = rows.Scan(&psize, &pval, &pavg); err != nil {
+		if err = rows.Scan(&height, &hash, &psize, &pval, &pavg, &winners); err != nil {
 			log.Errorf("Unable to scan for TicketPoolInfo fields: %v", err)
 		}
 		poolvals = append(poolvals, pval)
@@ -465,12 +513,14 @@ func (db *DB) RetrieveSDiff(ind int64) (float64, error) {
 func (db *DB) RetrieveLatestBlockSummary() (*apitypes.BlockDataBasic, error) {
 	bd := new(apitypes.BlockDataBasic)
 
+	var winners string
 	err := db.QueryRow(db.getLatestBlockSQL).Scan(&bd.Height, &bd.Size,
 		&bd.Hash, &bd.Difficulty, &bd.StakeDiff, &bd.Time,
-		&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg)
+		&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg, &winners)
 	if err != nil {
 		return nil, err
 	}
+	bd.PoolInfo.Winners = strings.Split(winners, ";")
 
 	return bd, nil
 }
@@ -507,12 +557,15 @@ func (db *DB) RetrieveBestBlockHeight() (int64, error) {
 func (db *DB) RetrieveBlockSummaryByHash(hash string) (*apitypes.BlockDataBasic, error) {
 	bd := new(apitypes.BlockDataBasic)
 
+	var winners string
 	err := db.QueryRow(db.getBlockByHashSQL, hash).Scan(&bd.Height, &bd.Size, &bd.Hash,
 		&bd.Difficulty, &bd.StakeDiff, &bd.Time,
-		&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg)
+		&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg, &winners)
 	if err != nil {
 		return nil, err
 	}
+
+	bd.PoolInfo.Winners = strings.Split(winners, ";")
 	return bd, nil
 }
 
@@ -523,12 +576,14 @@ func (db *DB) RetrieveBlockSummary(ind int64) (*apitypes.BlockDataBasic, error) 
 	// Three different ways
 
 	// 1. chained QueryRow/Scan only
+	var winners string
 	err := db.QueryRow(db.getBlockSQL, ind).Scan(&bd.Height, &bd.Size, &bd.Hash,
 		&bd.Difficulty, &bd.StakeDiff, &bd.Time,
-		&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg)
+		&bd.PoolInfo.Size, &bd.PoolInfo.Value, &bd.PoolInfo.ValAvg, &winners)
 	if err != nil {
 		return nil, err
 	}
+	bd.PoolInfo.Winners = strings.Split(winners, ";")
 
 	// 2. Prepare + chained QueryRow/Scan
 	// stmt, err := db.Prepare(getBlockSQL)
@@ -621,12 +676,14 @@ func (db *DB) StoreStakeInfoExtended(si *apitypes.StakeInfoExtended) error {
 	}
 	defer stmt.Close()
 
+	winners := strings.Join(si.PoolInfo.Winners, ";")
+
 	res, err := stmt.Exec(&si.Feeinfo.Height,
 		&si.Feeinfo.Number, &si.Feeinfo.Min, &si.Feeinfo.Max, &si.Feeinfo.Mean,
 		&si.Feeinfo.Median, &si.Feeinfo.StdDev,
 		&si.StakeDiff, // no next or estimates
 		&si.PriceWindowNum, &si.IdxBlockInWindow, &si.PoolInfo.Size,
-		&si.PoolInfo.Value, &si.PoolInfo.ValAvg)
+		&si.PoolInfo.Value, &si.PoolInfo.ValAvg, &winners)
 	if err != nil {
 		return err
 	}
@@ -646,16 +703,19 @@ func (db *DB) StoreStakeInfoExtended(si *apitypes.StakeInfoExtended) error {
 func (db *DB) RetrieveLatestStakeInfoExtended() (*apitypes.StakeInfoExtended, error) {
 	si := new(apitypes.StakeInfoExtended)
 
+	var winners string
 	err := db.QueryRow(db.getLatestStakeInfoExtendedSQL).Scan(
 		&si.Feeinfo.Height, &si.Feeinfo.Number, &si.Feeinfo.Min,
 		&si.Feeinfo.Max, &si.Feeinfo.Mean,
 		&si.Feeinfo.Median, &si.Feeinfo.StdDev,
 		&si.StakeDiff, // no next or estimates
 		&si.PriceWindowNum, &si.IdxBlockInWindow, &si.PoolInfo.Size,
-		&si.PoolInfo.Value, &si.PoolInfo.ValAvg)
+		&si.PoolInfo.Value, &si.PoolInfo.ValAvg, &winners)
 	if err != nil {
 		return nil, err
 	}
+
+	si.PoolInfo.Winners = strings.Split(winners, ";")
 
 	return si, nil
 }
@@ -664,18 +724,32 @@ func (db *DB) RetrieveLatestStakeInfoExtended() (*apitypes.StakeInfoExtended, er
 func (db *DB) RetrieveStakeInfoExtended(ind int64) (*apitypes.StakeInfoExtended, error) {
 	si := new(apitypes.StakeInfoExtended)
 
+	var winners string
 	err := db.QueryRow(db.getStakeInfoExtendedSQL, ind).Scan(&si.Feeinfo.Height,
 		&si.Feeinfo.Number, &si.Feeinfo.Min, &si.Feeinfo.Max, &si.Feeinfo.Mean,
 		&si.Feeinfo.Median, &si.Feeinfo.StdDev,
 		&si.StakeDiff, // no next or estimates
 		&si.PriceWindowNum, &si.IdxBlockInWindow, &si.PoolInfo.Size,
-		&si.PoolInfo.Value, &si.PoolInfo.ValAvg)
+		&si.PoolInfo.Value, &si.PoolInfo.ValAvg, &winners)
 	if err != nil {
 		return nil, err
 	}
 
+	si.PoolInfo.Winners = strings.Split(winners, ";")
+
 	return si, nil
 }
+
+// RetrieveWinners returns the winners for block ind
+// func (db *DB) RetrieveWinners(ind int64) ([]string, error) {
+// 	var winners string
+// 	err := db.QueryRow(db.getStakeInfoWinnersSQL, ind).Scan(&winners)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	return strings.Split(winners, ";"), nil
+// }
 
 func logDBResult(res sql.Result) error {
 	if log.Level() > btclog.LevelTrace {

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -101,7 +101,7 @@ func NewDB(db *sql.DB) (*DB, error) {
 	d.insertBlockSQL = fmt.Sprintf(`
         INSERT OR REPLACE INTO %s(
             height, size, hash, diff, sdiff, time, poolsize, poolval, poolavg, winners
-        ) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, TableNameSummaries)
 
 	d.getBlockSizeRangeSQL = fmt.Sprintf(`select size from %s where height between ? and ?`,

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -256,12 +256,16 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) (int64, error) {
 		//winningTickets := db.sDB.BestNode.Winners()
 
 		if (i-1)%rescanLogBlockChunk == 0 && i-1 != startHeight || i == startHeight {
-			endRangeBlock := rescanLogBlockChunk * (1 + (i-1)/rescanLogBlockChunk)
-			if endRangeBlock > height {
-				endRangeBlock = height
+			if i == 0 {
+				log.Infof("Scanning genesis block.")
+			} else {
+				endRangeBlock := rescanLogBlockChunk * (1 + (i-1)/rescanLogBlockChunk)
+				if endRangeBlock > height {
+					endRangeBlock = height
+				}
+				log.Infof("Scanning blocks %d to %d (%d live)...",
+					i, endRangeBlock, numLive)
 			}
-			log.Infof("Scanning blocks %d to %d (%d live)...",
-				i, endRangeBlock, numLive)
 		}
 
 		var tpi *apitypes.TicketPoolInfo

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -270,12 +270,11 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) (int64, error) {
 			if i != 0 {
 				log.Warnf("Unable to find block (%s) in pool info cache. Resync is malfunctioning!", blockhash.String())
 			}
-			ticketPoolInfo, sdbHeight := db.sDB.PoolInfoBest()
-			if int64(sdbHeight) != i {
+			tpi = db.sDB.PoolInfoBest()
+			if int64(tpi.Height) != i {
 				log.Errorf("Collected block height %d != stake db height %d. Pool info "+
-					"will not match the rest of this block's data.", height, i)
+					"will not match the rest of this block's data.", tpi.Height, i)
 			}
-			tpi = &ticketPoolInfo
 		}
 
 		header := block.MsgBlock().Header

--- a/dcrdataapi/apitypes.go
+++ b/dcrdataapi/apitypes.go
@@ -236,9 +236,11 @@ type Status struct {
 
 // TicketPoolInfo models data about ticket pool
 type TicketPoolInfo struct {
-	Size   uint32  `json:"size"`
-	Value  float64 `json:"value"`
-	ValAvg float64 `json:"valavg"`
+	Height  uint32   `json:"height"`
+	Size    uint32   `json:"size"`
+	Value   float64  `json:"value"`
+	ValAvg  float64  `json:"valavg"`
+	Winners []string `json:"winners"`
 }
 
 // TicketPoolValsAndSizes models two arrays, one each for ticket values and

--- a/dcrdataapi/apitypes.go
+++ b/dcrdataapi/apitypes.go
@@ -236,13 +236,11 @@ type Status struct {
 
 // TicketPoolInfo models data about ticket pool
 type TicketPoolInfo struct {
-	Height         uint32   `json:"height"`
-	Size           uint32   `json:"size"`
-	Value          float64  `json:"value"`
-	ValAvg         float64  `json:"valavg"`
-	Winners        []string `json:"winners"`
-	Expires        []string `json:"expires"`
-	ExpiresRevoked []bool   `json:"expires_revoked"`
+	Height  uint32   `json:"height"`
+	Size    uint32   `json:"size"`
+	Value   float64  `json:"value"`
+	ValAvg  float64  `json:"valavg"`
+	Winners []string `json:"winners"`
 }
 
 // TicketPoolValsAndSizes models two arrays, one each for ticket values and

--- a/dcrdataapi/apitypes.go
+++ b/dcrdataapi/apitypes.go
@@ -236,11 +236,13 @@ type Status struct {
 
 // TicketPoolInfo models data about ticket pool
 type TicketPoolInfo struct {
-	Height  uint32   `json:"height"`
-	Size    uint32   `json:"size"`
-	Value   float64  `json:"value"`
-	ValAvg  float64  `json:"valavg"`
-	Winners []string `json:"winners"`
+	Height         uint32   `json:"height"`
+	Size           uint32   `json:"size"`
+	Value          float64  `json:"value"`
+	ValAvg         float64  `json:"valavg"`
+	Winners        []string `json:"winners"`
+	Expires        []string `json:"expires"`
+	ExpiresRevoked []bool   `json:"expires_revoked"`
 }
 
 // TicketPoolValsAndSizes models two arrays, one each for ticket values and

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -72,6 +72,7 @@ type explorerDataSource interface {
 	SpendingTransactions(fundingTxID string) ([]string, []uint32, []uint32, error)
 	AddressHistory(address string, N, offset int64) ([]*dbtypes.AddressRow, *AddressBalance, error)
 	FillAddressTransactions(addrInfo *AddressInfo) error
+	BlockMissedVotes(blockHash string) ([]string, error)
 }
 
 type explorerUI struct {

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -76,6 +76,37 @@ type explorerDataSource interface {
 	BlockMissedVotes(blockHash string) ([]string, error)
 }
 
+// TicketStatusText generates the text to display on the explorer's transaction
+// page for the "POOL STATUS" field.
+func TicketStatusText(s dbtypes.TicketSpendType, p dbtypes.TicketPoolStatus) string {
+	switch p {
+	case dbtypes.PoolStatusLive:
+		return "In Live Ticket Pool"
+	case dbtypes.PoolStatusVoted:
+		return "Voted"
+	case dbtypes.PoolStatusExpired:
+		switch s {
+		case dbtypes.TicketUnspent:
+			return "Expired, Unrevoked"
+		case dbtypes.TicketRevoked:
+			return "Expired, Revoked"
+		default:
+			return "invalid ticket state"
+		}
+	case dbtypes.PoolStatusMissed:
+		switch s {
+		case dbtypes.TicketUnspent:
+			return "Missed, Unrevoked"
+		case dbtypes.TicketRevoked:
+			return "Missed, Reevoked"
+		default:
+			return "invalid ticket state"
+		}
+	default:
+		return "Immature"
+	}
+}
+
 type explorerUI struct {
 	Mux             *chi.Mux
 	blockData       explorerDataSourceLite

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -70,6 +70,7 @@ type explorerDataSourceLite interface {
 type explorerDataSource interface {
 	SpendingTransaction(fundingTx string, vout uint32) (string, uint32, int8, error)
 	SpendingTransactions(fundingTxID string) ([]string, []uint32, []uint32, error)
+	PoolStatusForTicket(txid string) (dbtypes.TicketSpendType, dbtypes.TicketPoolStatus, error)
 	AddressHistory(address string, N, offset int64) ([]*dbtypes.AddressRow, *AddressBalance, error)
 	FillAddressTransactions(addrInfo *AddressInfo) error
 	BlockMissedVotes(blockHash string) ([]string, error)

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -4,6 +4,7 @@
 package explorer
 
 import (
+	"database/sql"
 	"io"
 	"net/http"
 	"strconv"
@@ -103,6 +104,14 @@ func (exp *explorerUI) Block(w http.ResponseWriter, r *http.Request) {
 	}
 	if count == len(data.Tx) {
 		data.TxAvailable = false
+	}
+
+	if !exp.liteMode {
+		var err error
+		data.Misses, err = exp.explorerSource.BlockMissedVotes(hash)
+		if err != nil && err != sql.ErrNoRows {
+			log.Warnf("Unable to retrieve missed votes for block %s: %v", hash, err)
+		}
 	}
 
 	pageData := struct {

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -169,6 +169,19 @@ func (exp *explorerUI) TxPage(w http.ResponseWriter, r *http.Request) {
 				Index: spendingTxVinInds[i],
 			}
 		}
+		if tx.Type == "Ticket" {
+			spendStatus, poolStatus, err := exp.explorerSource.PoolStatusForTicket(hash)
+			if err != nil {
+				log.Errorf("Unable to retrieve ticket spend and pool status for %s: %v", hash, err)
+			} else {
+				if tx.Mature == "False" {
+					tx.TicketInfo.PoolStatus = "immature"
+				} else {
+					tx.TicketInfo.PoolStatus = poolStatus.String()
+				}
+				tx.TicketInfo.SpendStatus = spendStatus.String()
+			}
+		}
 	}
 
 	pageData := struct {

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -63,7 +63,13 @@ type TxInfo struct {
 	FormattedTime   string
 	Mature          string
 	VoteFundsLocked string
-	TicketMaturity  int64
+	TicketInfo
+}
+
+type TicketInfo struct {
+	TicketMaturity int64
+	PoolStatus     string
+	SpendStatus    string
 }
 
 // TxInID models the identity of a spending transaction input

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -117,6 +117,7 @@ type BlockInfo struct {
 	Tickets               []*TxBasic
 	Revs                  []*TxBasic
 	Votes                 []*TxBasic
+	Misses                []string
 	Nonce                 uint32
 	VoteBits              uint16
 	FinalState            string

--- a/main.go
+++ b/main.go
@@ -195,9 +195,9 @@ func mainCore() error {
 		}
 	}
 
-	if sqliteDB.GetStakeInfoHeight() > int64(heightDB) {
-		// charge stakedb pool info cache
-		if err = sqliteDB.ChargePoolInfoCache(int64(heightDB)); err != nil {
+	if sqliteDB.GetStakeInfoHeight() >= int64(heightDB) {
+		// charge stakedb pool info cache, including previous
+		if err = sqliteDB.ChargePoolInfoCache(int64(heightDB) - 1); err != nil {
 			return fmt.Errorf("Failed to charge pool info cache: %v", err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -119,7 +119,7 @@ func mainCore() error {
 
 	// PostgreSQL
 	var db *dcrpg.ChainDB
-	var newPGIndexes, updateAllAddresses bool
+	var newPGIndexes, updateAllAddresses, updateAllVotes bool
 	if usePG {
 		pgHost, pgPort := cfg.PGHost, ""
 		if !strings.HasPrefix(pgHost, "/") {
@@ -198,7 +198,7 @@ func mainCore() error {
 		if blocksBehind > 7500 {
 			log.Infof("Setting PSQL sync to rebuild address table after large "+
 				"import (%d blocks).", blocksBehind)
-			updateAllAddresses = true
+			updateAllAddresses, updateAllVotes = true, true
 			if blocksBehind > 40000 {
 				log.Infof("Setting PSQL sync to drop indexes prior to bulk data "+
 					"import (%d blocks).", blocksBehind)
@@ -225,7 +225,7 @@ func mainCore() error {
 		// Launch the sync functions for both DBs
 		go sqliteDB.SyncDBAsync(sqliteSyncRes, quit)
 		go db.SyncChainDBAsync(pgSyncRes, dcrdClient, quit,
-			newPGIndexes, updateAllAddresses)
+			updateAllAddresses, updateAllVotes, newPGIndexes)
 
 		// Wait for the results
 		sqliteRes := <-sqliteSyncRes

--- a/main.go
+++ b/main.go
@@ -194,7 +194,7 @@ func mainCore() error {
 		if blocksBehind > 7500 {
 			log.Infof("Setting PSQL sync to rebuild address table after large "+
 				"import (%d blocks).", blocksBehind)
-			updateAllAddresses, updateAllVotes = true, true
+			updateAllAddresses = true
 			if blocksBehind > 40000 {
 				log.Infof("Setting PSQL sync to drop indexes prior to bulk data "+
 					"import (%d blocks).", blocksBehind)

--- a/main.go
+++ b/main.go
@@ -143,10 +143,6 @@ func mainCore() error {
 			return err
 		}
 
-		if err = db.SetupTables(); err != nil {
-			return err
-		}
-
 		var idxExists bool
 		idxExists, err = db.ExistsIndexVinOnVins()
 		if !idxExists || err != nil {

--- a/main.go
+++ b/main.go
@@ -143,6 +143,10 @@ func mainCore() error {
 			return err
 		}
 
+		if err = db.VersionCheck(); err != nil {
+			return err
+		}
+
 		var idxExists bool
 		idxExists, err = db.ExistsIndexVinOnVins()
 		if !idxExists || err != nil {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -154,8 +154,8 @@ func (p *mempoolMonitor) TxHandler(client *rpcclient.Client) {
 				// txHeight = tx.MsgTx().TxIn[0].BlockHeight // uh, no
 			case stake.TxTypeSSGen:
 				// Vote
-				voteHash := &tx.MsgTx().TxIn[1].PreviousOutPoint.Hash
-				log.Tracef("Received vote %v for ticket %v", tx.Hash(), voteHash)
+				ticketHash := &tx.MsgTx().TxIn[1].PreviousOutPoint.Hash
+				log.Tracef("Received vote %v for ticket %v", tx.Hash(), ticketHash)
 				// TODO: Show subsidy for this vote (Vout[2] - Vin[1] ?)
 				continue
 			case stake.TxTypeSSRtx:

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -537,13 +537,8 @@ func (db *StakeDatabase) PoolInfoBest() *apitypes.TicketPoolInfo {
 	liveTickets := db.BestNode.LiveTickets()
 	winningTickets := db.BestNode.Winners()
 	height := db.BestNode.Height()
-	expiredTickets, expireRevoked := db.expires()
+	// expiredTickets, expireRevoked := db.expires()
 	db.nodeMtx.RUnlock()
-
-	expires := make([]string, len(expiredTickets))
-	for i := range expiredTickets {
-		expires[i] = expiredTickets[i].String()
-	}
 
 	db.liveTicketMtx.Lock()
 	var poolValue int64
@@ -582,13 +577,11 @@ func (db *StakeDatabase) PoolInfoBest() *apitypes.TicketPoolInfo {
 	}
 
 	return &apitypes.TicketPoolInfo{
-		Height:         height,
-		Size:           uint32(poolSize),
-		Value:          poolCoin,
-		ValAvg:         valAvg,
-		Winners:        winners,
-		Expires:        expires,
-		ExpiresRevoked: expireRevoked,
+		Height:  height,
+		Size:    uint32(poolSize),
+		Value:   poolCoin,
+		ValAvg:  valAvg,
+		Winners: winners,
 	}
 }
 

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -95,6 +95,10 @@ func NewStakeDatabase(client *rpcclient.Client, params *chaincfg.Params,
 		PoolDB:          poolDB,
 	}
 
+	// Put the genesis block in the pool info cache since stakedb starts with
+	// genesis. Hence it will never be connected, how TPI is usually cached.
+	sDB.poolInfo.Set(*params.GenesisHash, &apitypes.TicketPoolInfo{})
+
 	dbName := DefaultStakeDbName
 	if len(dbNameOpt) > 0 {
 		dbName = dbNameOpt[0]

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -505,11 +505,6 @@ func (db *StakeDatabase) Open(dbName string) error {
 	return err
 }
 
-// Close closes the database.
-func (db *StakeDatabase) Close() error {
-	return db.StakeDB.Close()
-}
-
 // Close will close the ticket pool and stake databases.
 func (db *StakeDatabase) Close() error {
 	err1 := db.PoolDB.Close()

--- a/version.go
+++ b/version.go
@@ -12,7 +12,7 @@ var ver = version{
 	Major: 2,
 	Minor: 0,
 	Patch: 0,
-	Label: "beta"}
+	Label: ""}
 
 // CommitHash may be set on the build command line:
 // go build -ldflags "-X main.CommitHash=`git rev-parse --short HEAD`"

--- a/views/block.tmpl
+++ b/views/block.tmpl
@@ -231,6 +231,40 @@
             </div>
         </div>
 
+        {{if ge .Height .StakeValidationHeight}}
+        <div class="row">
+            <span class="anchor" id="misses"></span>
+            <div class="col-md-12">
+                <h4><span>Missed Votes</span></h4>
+                {{if not .Misses}}
+                    <table class="table table-sm striped">
+                            <tr>
+                                <td>No missed votes in this block.
+                                </td>
+                            </tr>
+                    </table>
+                {{else}}
+                    <table class="table table-sm striped">
+                        <thead>
+                            <th>Ticket ID</th>
+                        </thead>
+                        <tbody>
+                            {{range .Misses}}
+                            <tr>
+                                <td class="break-word">
+                                    <span>
+                                        <a class="hash lh1rem" href="/tx/{{.}}">{{.}}</a>
+                                    </span>
+                                </td>
+                            </tr>
+                            {{end}}
+                        </tbody>
+                    </table>
+                {{end}}
+            </div>
+        </div>
+        {{end}}
+
         <div class="row">
             <span class="anchor" id="tickets"></span>
             <div class="col-md-12">

--- a/views/tx.tmpl
+++ b/views/tx.tmpl
@@ -46,22 +46,20 @@
                         {{end}}
                     {{end}}
                 {{end}}
-                {{if eq .Type "Ticket"}}
-                    {{if (index .SpendingTxns 0).Hash}}
-                        <tr>
-                            <td width="90" class="text-right pr-2 h1rem p03rem0 xs-w91">SPENT IN</td>
-                            <td>
-                                <a href="/tx/{{(index .SpendingTxns 0).Hash}}">{{(index .SpendingTxns 0).Hash}}</a>
-                            </td>
-                        </tr>
-                    {{end}}
-                {{end}}
                 <tr>
                     <td class="text-right pr-2 h1rem p03rem0">TYPE</td>
                     <td>
                         {{.Type}}
                     </td>
                 </tr>
+                {{if eq .Type "Ticket"}}
+                <tr>
+                    <td width="90" class="text-right pr-2 h1rem p03rem0 xs-w91">POOL STATUS</td>
+                    <td>
+                        {{if ne .TicketInfo.SpendStatus "voted"}} {{.TicketInfo.PoolStatus}}  / {{end}} {{if (index .SpendingTxns 0).Hash}}<a href="/tx/{{(index .SpendingTxns 0).Hash}}">{{.TicketInfo.SpendStatus}}</a>{{else}}{{.TicketInfo.SpendStatus}}{{end}}
+                    </td>
+                </tr>
+                {{end}}
                 {{if eq .Mature "True"}}
                     <td class="text-right pr-2 h1rem p03rem0">MATURE</td><td>{{.Mature}}</td>
                 {{end}}
@@ -75,13 +73,13 @@
                                     <div
                                         class="progress-bar"
                                         role="progressbar"
-                                        style="width: {{percentage (subtract .Confirmations 1) .TicketMaturity}}%; background: #2ed8a3;"
+                                        style="width: {{percentage (subtract .Confirmations 1) .TicketInfo.TicketMaturity}}%; background: #2ed8a3;"
                                         aria-valuenow="{{.Confirmations}}"
                                         aria-valuemin="0"
                                         aria-valuemax="256"
                                     >
                                         <span style="color:#383b41" class="nowrap pl-1 pr-1">
-                                            Immature, {{ if eq .Type "Ticket"}}eligible to vote{{else}}spendable{{end}} in {{ if eq .Confirmations .TicketMaturity }}next block{{else}}{{subtract (add .TicketMaturity 1) .Confirmations}} blocks{{end}}
+                                            Immature, {{ if eq .Type "Ticket"}}eligible to vote{{else}}spendable{{end}} in {{ if eq .Confirmations .TicketInfo.TicketMaturity }}next block{{else}}{{subtract (add .TicketInfo.TicketMaturity 1) .Confirmations}} blocks{{end}}
                                         </span>
                                     </div>
                                 </div>


### PR DESCRIPTION
**IMPORTANT**:  This requires removing and rebuilding all DBs, including dcrdata.sqlt.db, the PostgreSQL tables, and the stakedb (the ffldb_stake folder).

Adds stake-related tables, including: tickets, votes, misses, winners.
Note that this PR modifies `apitypes.TicketPoolInfo` to include height at which the result applies, and winning tickets drawn at that height.  Existing fields are unchanged.

TODO:
- [x] winners stored only in sqlite, need to store in the full DB (e.g. postgresql) too
- [x] SELECT statements
- [x] show missed votes (the ticket that could have been spent as a vote) on the block pages
<s>- [ ] proof-of-concept page to exercise the table queries</s>  This was ill-defined

Bonuses:
- changes the syntax for rebuilddb2 command line tool so that "-u" is removed, but the behaviour is now the default.  Use "-a/--addrspends-no-batch" to do the address table updates online (slow, impractical for initial build).
- duplicate entries in vins and vouts are removed prior to their indexing so that the index may be UNIQUE.
- Switch a bunch of "dup check"-enabled insert statements to use the "upsert" instead of "on conflict ... do nothing" behaviour.