### PR TITLE
Address QR code [WIP]

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -151,6 +151,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/skip2/go-qrcode"
+  packages = [".","bitset","reedsolomon"]
+  revision = "80895b4a9eff675bc0f8ea09f60106bca9ac44c8"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/crypto"
   packages = ["nacl/secretbox","pbkdf2","poly1305","ripemd160","salsa20/salsa","scrypt"]
   revision = "9419663f5a44be8b34ca85f08abc5fe1be11f8a3"
@@ -170,6 +176,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4c7eec3b639d27568fbb3e9f647cb6d0f9dc41c4118242735c46b00ba72b2108"
+  inputs-digest = "361d7f507023515525c1fce174aac94c6443cb6fa6bf9733c5c93659ebb12fe7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -69,3 +69,7 @@
 [[constraint]]
   branch = "master"
   name = "golang.org/x/net"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/skip2/go-qrcode"

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -7,6 +7,7 @@ package explorer
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -31,6 +32,7 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 	"github.com/rs/cors"
+	"github.com/skip2/go-qrcode"
 	"golang.org/x/net/websocket"
 )
 
@@ -426,6 +428,10 @@ func (exp *explorerUI) addressPage(w http.ResponseWriter, r *http.Request) {
 	for i, v := range addrData.Transactions {
 		confirmHeights[i] = exp.NewBlockData.Height - int64(v.Confirmations)
 	}
+
+	png, err := qrcode.Encode(addrData.Address, qrcode.Medium, 256)
+	addrData.QRCode = base64.StdEncoding.EncodeToString(png)
+
 	pageData := struct {
 		Data          *AddressInfo
 		ConfirmHeight []int64

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -145,6 +145,7 @@ type AddressInfo struct {
 	Unspent          dcrutil.Amount
 	Balance          *AddressBalance
 	Path             string
+	QRCode           string
 }
 
 // AddressBalance represents the number and value of spent and unspent outputs

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -11,6 +11,9 @@
             <div class="col-md-8 col-sm-6">
                 <h4>Address</h4>
                 <div class="mono">{{.Address}}</div>
+                <div style="width: 280px; text-align: center">
+                    <img src="data:image/png;base64,{{.QRCode}}">
+                </div>
                 <table class="table-centered-1rem">
                     {{if .Balance}}
                     {{if not .KnownFundingTxns}}


### PR DESCRIPTION
This adds QR code support for address pages, which is handy for mobile wallets.

<img width="892" alt="qr" src="https://user-images.githubusercontent.com/25571523/34069038-e5c93530-e1fc-11e7-87eb-fde7ec3130c6.png">

This is currently just a quick proof of concept. Implementation considerations:
- Generate the image on server or client? ( currently server-side )
- Show by default or hide behind a link/toggle? ( currently shown by default )

I'm leaning towards the current server-side implementation, so as to not load extra js ( smallest qr code lib out there is ~20kb minified ). There is some overhead in generating the image so ideally only the users who actually use this should incur that overhead. Maybe we can just have link to "generate qr code" which reloads the page with "?qr=1" appended to the url to gate the logic.

