### PR TITLE
Fix websocket update of PoW diff

### DIFF
--- a/views/extras.tmpl
+++ b/views/extras.tmpl
@@ -208,7 +208,7 @@
             }
             var ex = newBlock.extra
             if ($("#bsubsidy_total").text() !== "") {
-                $("#difficulty").html(humanize.decimalParts(ex.difficulty/100000000, false, 8))
+                $("#difficulty").html(humanize.decimalParts(ex.difficulty, true, 8))
                 $("#bsubsidy_total").html(humanize.decimalParts(ex.subsidy.total/100000000, false, 8))
                 $("#bsubsidy_pow").html(humanize.decimalParts(ex.subsidy.pow/100000000, false, 8))
                 $("#bsubsidy_pos").html(humanize.decimalParts((ex.subsidy.pos/500000000), false, 8)) // 5 votes per block (usually)


### PR DESCRIPTION
The javascript for PoW diff update was configured for a DCR amount with no commas.  Do not divide by 1e8, and use commas.