### PR TITLE
Amendments to the address page summary

### DIFF
--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1082,7 +1082,9 @@ func (db *wiredDB) GetExplorerAddress(address string, count, offset int64) *expl
 			if len(y.ScriptPubKey.Addresses) != 0 {
 				if address == y.ScriptPubKey.Addresses[0] {
 					t, _ := dcrutil.NewAmount(y.Value)
-					totalreceived += t
+					if t > 0 {
+						totalreceived += t
+					}
 					numReceiving++
 				}
 			}
@@ -1091,7 +1093,9 @@ func (db *wiredDB) GetExplorerAddress(address string, count, offset int64) *expl
 			if u.PrevOut != nil && len(u.PrevOut.Addresses) != 0 {
 				if address == u.PrevOut.Addresses[0] {
 					t, _ := dcrutil.NewAmount(*u.AmountIn)
-					totalsent += t
+					if t > 0 {
+						totalsent += t
+					}
 					numSpending++
 				}
 			}

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1112,6 +1112,7 @@ func (db *wiredDB) GetExplorerAddress(address string, count, offset int64) *expl
 	return &explorer.AddressInfo{
 		Address:          address,
 		Limit:            count,
+		MaxLimit:         maxcount,
 		Offset:           offset,
 		Transactions:     addressTxs,
 		NumFundingTxns:   numFundingTxns,

--- a/db/dcrsqlite/apisource.go
+++ b/db/dcrsqlite/apisource.go
@@ -1126,27 +1126,28 @@ func (db *wiredDB) GetExplorerAddress(address string, count, offset int64) *expl
 		Balance:           balance,
 	}
 }
+
 func ValidateNetworkAddress(address dcrutil.Address, p *chaincfg.Params) bool {
 	return address.IsForNet(p)
 }
 
-// SearchRawTransactionsForUnconfirmedTransactions returns the number of unconfirmed transactions,
+// CountUnconfirmedTransactions returns the number of unconfirmed transactions involving the specified address,
 // given a maximum possible unconfirmed
-func (db *wiredDB) SearchRawTransactionsForUnconfirmedTransactions(address string, offset int64, maxUnconfirmedPossible int64) (numUnconfirmed int64, err error) {
+func (db *wiredDB) CountUnconfirmedTransactions(address string, maxUnconfirmedPossible int64) (numUnconfirmed int64, err error) {
 	addr, err := dcrutil.DecodeAddress(address)
 	if err != nil {
 		log.Infof("Invalid address %s: %v", address, err)
-		return 0, err
+		return
 	}
-	txs, err := db.client.SearchRawTransactionsVerbose(addr, int(offset), int(maxUnconfirmedPossible), true, true, nil)
+	txs, err := db.client.SearchRawTransactionsVerbose(addr, 0, int(maxUnconfirmedPossible), true, true, nil)
 	if err != nil {
 		log.Warnf("GetAddressTransactionsRaw failed for address %s: %v", addr, err)
-		return 0, err
+		return
 	}
 	for _, tx := range txs {
 		if tx.Confirmations == 0 {
 			numUnconfirmed++
 		}
 	}
-	return numUnconfirmed, nil
+	return
 }

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -41,10 +41,11 @@ const (
 )
 
 const (
-	maxExplorerRows          = 2000
-	minExplorerRows          = 20
-	defaultAddressRows int64 = 20
-	MaxAddressRows     int64 = 1000
+	maxExplorerRows              = 2000
+	minExplorerRows              = 20
+	defaultAddressRows     int64 = 20
+	MaxAddressRows         int64 = 1000
+	MaxUnconfirmedPossible int64 = 1000
 )
 
 // explorerDataSourceLite implements an interface for collecting data for the
@@ -60,6 +61,7 @@ type explorerDataSourceLite interface {
 	SendRawTransaction(txhex string) (string, error)
 	GetHeight() int
 	GetChainParams() *chaincfg.Params
+	SearchRawTransactionsForUnconfirmedTransactions(address string, offset int64, maxUnconfirmedPossible int64) (int64, error)
 }
 
 // explorerDataSource implements extra data retrieval functions that require a

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -61,7 +61,7 @@ type explorerDataSourceLite interface {
 	SendRawTransaction(txhex string) (string, error)
 	GetHeight() int
 	GetChainParams() *chaincfg.Params
-	SearchRawTransactionsForUnconfirmedTransactions(address string, offset int64, maxUnconfirmedPossible int64) (int64, error)
+	CountUnconfirmedTransactions(address string, maxUnconfirmedPossible int64) (int64, error)
 }
 
 // explorerDataSource implements extra data retrieval functions that require a

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -250,6 +250,11 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 		addrData.KnownFundingTxns = balance.NumSpent + balance.NumUnspent
 		addrData.Balance = balance
 		addrData.Path = r.URL.Path
+		addrData.KnownTransactions = (balance.NumSpent * 2) + balance.NumUnspent
+		addrData.NumTransactions = int64(len(addrData.Transactions))
+		if addrData.NumTransactions > addrData.Limit {
+			addrData.NumTransactions = addrData.Limit
+		}
 		addrData.Fullmode = true
 		// still need []*AddressTx filled out and NumUnconfirmed
 
@@ -259,6 +264,10 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 			log.Errorf("Unable to fill address %s transactions: %v", address, err)
 			exp.ErrorPage(w, "Something went wrong...", "could not find transactions for that address", false)
 			return
+		}
+		addrData.NumUnconfirmed, err = exp.blockData.SearchRawTransactionsForUnconfirmedTransactions(address, addrData.Offset, MaxUnconfirmedPossible)
+		if err != nil {
+			log.Warnf("SearchRawTransactionsForUnconfirmedTransactions failed for address %s: %v", address, err)
 		}
 	}
 

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -265,7 +265,7 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 			exp.ErrorPage(w, "Something went wrong...", "could not find transactions for that address", false)
 			return
 		}
-		addrData.NumUnconfirmed, err = exp.blockData.SearchRawTransactionsForUnconfirmedTransactions(address, addrData.Offset, MaxUnconfirmedPossible)
+		addrData.NumUnconfirmed, err = exp.blockData.CountUnconfirmedTransactions(address, MaxUnconfirmedPossible)
 		if err != nil {
 			log.Warnf("SearchRawTransactionsForUnconfirmedTransactions failed for address %s: %v", address, err)
 		}

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -139,12 +139,12 @@ type AddressInfo struct {
 	MaxLimit          int64
 	Offset            int64
 	Transactions      []*AddressTx
-	NumFundingTxns    int64
-	NumSpendingTxns   int64
-	NumTransactions   int64
-	KnownTransactions int64
-	KnownFundingTxns  int64
-	NumUnconfirmed    int64
+	NumFundingTxns    int64 // The number of transactions paying to the address
+	NumSpendingTxns   int64 // The number of transactions spending from the address
+	NumTransactions   int64 // The number of transactions in the address
+	KnownTransactions int64 // The number of transactions in the address unlimited
+	KnownFundingTxns  int64 // The number of transactions paying to the address unlimited
+	NumUnconfirmed    int64 // The number of unconfirmed transactions in the address
 	TotalReceived     dcrutil.Amount
 	TotalSent         dcrutil.Amount
 	Unspent           dcrutil.Amount

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -134,22 +134,23 @@ type BlockInfo struct {
 
 // AddressInfo models data for display on the address page
 type AddressInfo struct {
-	Address          string
-	Limit            int64
-	MaxLimit         int64
-	Offset           int64
-	Transactions     []*AddressTx
-	NumFundingTxns   int64
-	NumSpendingTxns  int64
-	NumTransactions  int64
-	KnownFundingTxns int64
-	NumUnconfirmed   int64
-	TotalReceived    dcrutil.Amount
-	TotalSent        dcrutil.Amount
-	Unspent          dcrutil.Amount
-	Balance          *AddressBalance
-	Path             string
-	Fullmode         bool
+	Address           string
+	Limit             int64
+	MaxLimit          int64
+	Offset            int64
+	Transactions      []*AddressTx
+	NumFundingTxns    int64
+	NumSpendingTxns   int64
+	NumTransactions   int64
+	KnownTransactions int64
+	KnownFundingTxns  int64
+	NumUnconfirmed    int64
+	TotalReceived     dcrutil.Amount
+	TotalSent         dcrutil.Amount
+	Unspent           dcrutil.Amount
+	Balance           *AddressBalance
+	Path              string
+	Fullmode          bool
 }
 
 // AddressBalance represents the number and value of spent and unspent outputs

--- a/explorer/explorertypes.go
+++ b/explorer/explorertypes.go
@@ -136,6 +136,7 @@ type BlockInfo struct {
 type AddressInfo struct {
 	Address          string
 	Limit            int64
+	MaxLimit         int64
 	Offset           int64
 	Transactions     []*AddressTx
 	NumFundingTxns   int64

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -150,12 +150,9 @@
                             {{if ne .RecievedTotal 0.0}}
                                 <td class="text-right">{{template "decimalParts" (float64AsDecimalParts .RecievedTotal false)}}</td>
                             {{else}}
-<<<<<<< HEAD
-=======
                                 {{if eq .SentTotal 0.0}}
                                 <td class="text-right">sstxcommitment</td>
                                 {{else}}
->>>>>>> 3cf58e0... requested changes
                                 <td></td>
                             {{end}}
                             {{if ne .SentTotal 0.0}}

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -58,7 +58,7 @@
                     {{else}}
                     <tr  class="h2rem">
                         <td class="pr-2 lh1rem vam text-right xs-w91">TOTAL UNSPENT</td>
-                        {{if eq .TotalReceived 0}}
+                        {{if gt .KnownFundingTxns 999}}
                         <td class="fs28 mono nowrap d-flex align-items-center justify-content-end">unavailable</td>
                         {{else}}
                         <td class="fs28 mono nowrap fs16-decimal d-flex align-items-center justify-content-end">{{.Unspent}}</td>
@@ -66,7 +66,7 @@
                     </tr>
                     <tr>
                         <td class="text-right pr-2">RECEIVED</td>
-                        {{if eq .TotalReceived 0}}
+                        {{if gt .KnownFundingTxns 999}}
                         <td class="mono nowrap text-right">unavailable</td>
                         {{else}}
                         <td class="mono nowrap text-right">{{.TotalReceived}}</td>
@@ -74,7 +74,7 @@
                     </tr>
                     <tr>
                         <td class="text-right pr-2">SPENT</td>
-                        {{if eq .TotalReceived 0}}
+                        {{if gt .KnownFundingTxns 999}}
                         <td class="mono nowrap text-right">unavailable</td>
                         {{else}}
                         <td class="mono nowrap text-right">{{.TotalSent}}</td>

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -14,70 +14,59 @@
             </div>
             <div class="col-md-4 col-sm-6 d-flex pb-3">
                 <table>
-                    {{if .Fullmode}}
-                        {{if .Balance}}
-                        <tr class="h2rem">
-                            <td class="pr-2 lh1rem vam text-right xs-w91">TOTAL UNSPENT</td>
-                            <td class="fs28 mono nowrap fs16-decimal d-flex align-items-center justify-content-end">
-                                {{template "decimalParts" (amountAsDecimalParts .Balance.TotalUnspent true)}}<span class="pl-1 unit">DCR</span>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="text-right pr-2">RECEIVED</td>
-                            <td class="mono nowrap text-right">
-                                {{$received := add .Balance.TotalSpent .Balance.TotalUnspent}}
-                                {{template "decimalParts" (amountAsDecimalParts $received true)}}<span class="pl-1 unit">DCR</span>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="text-right pr-2">SPENT</td>
-                            <td class="mono nowrap text-right">
-                                {{template "decimalParts" (amountAsDecimalParts .Balance.TotalSpent true)}}<span class="pl-1 unit">DCR</span>
-                            </td>
-                        </tr>
-                        {{else}}
-                        <tr class="h2rem">
-                            <td class="pr-2 lh1rem vam text-right xs-w91">TOTAL UNSPENT</td>
-                            <td class="fs28 mono nowrap fs16-decimal d-flex align-items-center justify-content-end">
-                                <span class="pl-1 unit">0.000000000 DCR</span>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="text-right pr-2">RECEIVED</td>
-                            <td class="mono nowrap text-right">
-                                <span class="pl-1 unit">0.000000000 DCR</span>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="text-right pr-2">SPENT</td>
-                            <td class="mono nowrap text-right">
-                                <span class="pl-1 unit">0.000000000 DCR</span>
-                            </td>
-                        </tr>
-                        {{end}}
-                    {{else}}
                     <tr  class="h2rem">
                         <td class="pr-2 lh1rem vam text-right xs-w91">TOTAL UNSPENT</td>
-                        {{if eq .KnownFundingTxns .MaxLimit}}
-                        <td class="fs28 mono nowrap d-flex align-items-center justify-content-end">unavailable</td>
+                        {{if .Fullmode}}
+                            <td class="fs28 mono nowrap fs16-decimal d-flex align-items-center justify-content-end">
+                                {{if .Balance}}
+                                    {{template "decimalParts" (amountAsDecimalParts .Balance.TotalUnspent true)}}<span class="pl-1 unit">DCR</span>
+                                {{else}}
+                                <span class="pl-1 unit">0.000000000 DCR</span>
+                                {{end}}
+                            </td>
                         {{else}}
-                        <td class="fs28 mono nowrap fs16-decimal d-flex align-items-center justify-content-end">{{.Unspent}}</td>
+                            {{if ge .KnownTransactions .MaxLimit}}
+                            <td class="fs28 mono nowrap d-flex align-items-center justify-content-end">unavailable</td>
+                            {{else}}
+                            <td class="fs28 mono nowrap fs16-decimal d-flex align-items-center justify-content-end">{{.Unspent}}</td>
+                            {{end}}
                         {{end}}
                     </tr>
                     <tr>
                         <td class="text-right pr-2">RECEIVED</td>
-                        {{if eq .KnownFundingTxns .MaxLimit}}
-                        <td class="mono nowrap text-right">unavailable</td>
+                        {{if .Fullmode}}
+                            <td class="mono nowrap text-right">
+                                {{if .Balance}}
+                                    {{$received := add .Balance.TotalSpent .Balance.TotalUnspent}}
+                                    {{template "decimalParts" (amountAsDecimalParts $received true)}}<span class="pl-1 unit">DCR</span>
+                                {{else}}
+                                <span class="pl-1 unit">0.000000000 DCR</span>
+                                {{end}}
+                            </td>
                         {{else}}
-                        <td class="mono nowrap text-right">{{.TotalReceived}}</td>
+                            {{if ge .KnownTransactions .MaxLimit}}
+                            <td class="mono nowrap text-right">unavailable</td>
+                            {{else}}
+                            <td class="mono nowrap text-right">{{.TotalReceived}}</td>
+                            {{end}}
                         {{end}}
                     </tr>
                     <tr>
                         <td class="text-right pr-2">SPENT</td>
-                        {{if eq .KnownFundingTxns .MaxLimit}}
-                        <td class="mono nowrap text-right">unavailable</td>
+                        {{if .Fullmode}}
+                            <td class="mono nowrap text-right">
+                                {{if .Balance}}
+                                    {{template "decimalParts" (amountAsDecimalParts .Balance.TotalSpent true)}}<span class="pl-1 unit">DCR</span>
+                                {{else}}
+                                <span class="pl-1 unit">0.000000000 DCR</span>
+                                {{end}}
+                            </td>
                         {{else}}
-                        <td class="mono nowrap text-right">{{.TotalSent}}</td>
+                            {{if ge .KnownTransactions .MaxLimit}}
+                            <td class="mono nowrap text-right">unavailable</td>
+                            {{else}}
+                            <td class="mono nowrap text-right">{{.TotalSent}}</td>
+                            {{end}}
                         {{end}}
                     </tr>
                     {{if ne .NumUnconfirmed 0}}
@@ -88,8 +77,6 @@
                             </td>
                         </tr>
                     {{end}}
-                           
-                    {{end}}
                 </table>
             </div>
         </div>
@@ -98,14 +85,14 @@
             <div class="col">
                 <div class="d-flex flex-wrap align-items-center justify-content-end mb-1">
                     <h5 class="mr-auto mb-0">Transactions</h5>
-                    {{if lt .NumFundingTxns .KnownFundingTxns}}
+                    {{if lt .NumTransactions .KnownTransactions}}
                     <div div class="d-flex flex-wrap-reverse align-items-center justify-content-end">
-                        <span class="fs12 nowrap text-right"> {{intComma (add .Offset 1)}} &mdash; {{intComma (add .Offset .NumFundingTxns)}} transactions of {{intComma .KnownFundingTxns}}
-                            {{if lt .NumFundingTxns .KnownFundingTxns}}
-                            {{if not .Fullmode}}
+                        {{if .Fullmode}}
+                        <span class="fs12 nowrap text-right"> {{intComma (add .Offset 1)}} &mdash; {{intComma (add .Offset .NumFundingTxns)}} of {{intComma .KnownFundingTxns}} funding transactions
+                        {{else}}
+                        <span class="fs12 nowrap text-right"> {{intComma (add .Offset 1)}} &mdash; {{intComma (add .Offset .NumTransactions)}} of {{intComma .KnownTransactions}} transactions
                             <sup>*</sup>
-                            {{end}}
-                            {{end}}
+                        {{end}}
                         </span>
                         <nav aria-label="address transactions navigation" data-limit="{{.Limit}}" class="ml-2">
                             <ul class="pagination mb-0 pagination-sm">
@@ -116,7 +103,7 @@
                                         id="prev"
                                     >Previous</a>
                                 </li>
-                                <li class="page-item {{if lt (subtract .KnownFundingTxns .Offset) (add .Limit 1)}}disabled{{end}}">
+                                <li class="page-item {{if lt (subtract .KnownTransactions .Offset) (add .Limit 1)}}disabled{{end}}">
                                     <a
                                         class="page-link"
                                         href="{{.Path}}?n={{.Limit}}&start={{add .Offset .Limit}}"
@@ -128,7 +115,11 @@
                         </nav>
                     </div>
                     {{else}}
-                    <span class="fs12 nowrap text-right">{{intComma .KnownFundingTxns}} transaction{{if gt .KnownFundingTxns 1}}s{{end}}</span>
+                    {{if .Fullmode}}
+                    <span class="fs12 nowrap text-right">{{intComma .KnownFundingTxns}} funding transaction{{if gt .KnownFundingTxns 1}}s{{end}}</span>
+                    {{else}}
+                    <span class="fs12 nowrap text-right">{{intComma .KnownTransactions}} transaction{{if gt .KnownTransactions 1}}s{{end}}</span>
+                    {{end}}
                     {{end}}
                 </div>
                 {{if .Transactions}}
@@ -196,7 +187,7 @@
                 </table>
                 {{end}}
 
-                {{if lt .NumFundingTxns .KnownFundingTxns}}
+                {{if lt .NumTransactions .KnownTransactions}}
                 {{if not .Fullmode}}
                 <div>
                     *Limit of 1000 transactions shown in lite mode.
@@ -222,7 +213,7 @@
         </div>
     </div>
 
-    {{if lt .NumFundingTxns .KnownFundingTxns}}
+    {{if lt .NumTransactions .KnownTransactions}}
     <script>
         $("#pagesize-wrapper").removeClass("hidden")
         $("#pagesize").change(function(ev) {

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -58,7 +58,7 @@
                     {{else}}
                     <tr  class="h2rem">
                         <td class="pr-2 lh1rem vam text-right xs-w91">TOTAL UNSPENT</td>
-                        {{if gt .KnownFundingTxns 999}}
+                        {{if eq .KnownFundingTxns .MaxLimit}}
                         <td class="fs28 mono nowrap d-flex align-items-center justify-content-end">unavailable</td>
                         {{else}}
                         <td class="fs28 mono nowrap fs16-decimal d-flex align-items-center justify-content-end">{{.Unspent}}</td>
@@ -66,7 +66,7 @@
                     </tr>
                     <tr>
                         <td class="text-right pr-2">RECEIVED</td>
-                        {{if gt .KnownFundingTxns 999}}
+                        {{if eq .KnownFundingTxns .MaxLimit}}
                         <td class="mono nowrap text-right">unavailable</td>
                         {{else}}
                         <td class="mono nowrap text-right">{{.TotalReceived}}</td>
@@ -74,7 +74,7 @@
                     </tr>
                     <tr>
                         <td class="text-right pr-2">SPENT</td>
-                        {{if gt .KnownFundingTxns 999}}
+                        {{if eq .KnownFundingTxns .MaxLimit}}
                         <td class="mono nowrap text-right">unavailable</td>
                         {{else}}
                         <td class="mono nowrap text-right">{{.TotalSent}}</td>

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -56,24 +56,38 @@
                         </tr>
                         {{end}}
                     {{else}}
-                    <tr>
-                        <td class="pr-2 lh1rem vam text-right xs-w91">UNCONFIRMED</td>
-                        <td class="fs28 mono nowrap fs16-decimal d-flex align-items-center justify-content-end">
-                            {{.NumUnconfirmed}}
-                        </td>
+                    <tr  class="h2rem">
+                        <td class="pr-2 lh1rem vam text-right xs-w91">TOTAL UNSPENT</td>
+                        {{if eq .TotalReceived 0}}
+                        <td class="fs28 mono nowrap d-flex align-items-center justify-content-end">unavailable</td>
+                        {{else}}
+                        <td class="fs28 mono nowrap fs16-decimal d-flex align-items-center justify-content-end">{{.Unspent}}</td>
+                        {{end}}
                     </tr>
                     <tr>
                         <td class="text-right pr-2">RECEIVED</td>
+                        {{if eq .TotalReceived 0}}
+                        <td class="mono nowrap text-right">unavailable</td>
+                        {{else}}
                         <td class="mono nowrap text-right">{{.TotalReceived}}</td>
+                        {{end}}
                     </tr>
                     <tr>
-                        <td class="text-right pr-2">SENT</td>
+                        <td class="text-right pr-2">SPENT</td>
+                        {{if eq .TotalReceived 0}}
+                        <td class="mono nowrap text-right">unavailable</td>
+                        {{else}}
                         <td class="mono nowrap text-right">{{.TotalSent}}</td>
+                        {{end}}
                     </tr>
+                    {{if ne .NumUnconfirmed 0}}
                     <tr>
-                        <td class="text-right pr-2">UNSPENT</td>
-                        <td class="mono nowrap text-right">{{.Unspent}}</td>
+                        <td class="text-right pr-2">UNCONFIRMED</td>
+                        <td class="mono nowrap text-right">
+                            {{.NumUnconfirmed}} transaction{{if gt .NumUnconfirmed 0}}s{{end}}
+                        </td>
                     </tr>
+                    {{end}}
                            
                     {{end}}
                 </table>
@@ -86,7 +100,7 @@
                     <h5 class="mr-auto mb-0">Transactions</h5>
                     {{if lt .NumFundingTxns .KnownFundingTxns}}
                     <div div class="d-flex flex-wrap-reverse align-items-center justify-content-end">
-                        <span class="fs12 nowrap text-right">funding transactions {{intComma (add .Offset 1)}} &mdash; {{intComma (add .Offset .NumFundingTxns)}} of {{intComma .KnownFundingTxns}}
+                        <span class="fs12 nowrap text-right"> {{intComma (add .Offset 1)}} &mdash; {{intComma (add .Offset .NumFundingTxns)}} transactions of {{intComma .KnownFundingTxns}}
                             {{if lt .NumFundingTxns .KnownFundingTxns}}
                             {{if not .Fullmode}}
                             <sup>*</sup>
@@ -114,7 +128,7 @@
                         </nav>
                     </div>
                     {{else}}
-                    <span class="fs12 nowrap text-right">{{intComma .KnownFundingTxns}} funding transaction{{if gt 1 .KnownFundingTxns}}s{{end}}</span>
+                    <span class="fs12 nowrap text-right">{{intComma .KnownFundingTxns}} transaction{{if gt .KnownFundingTxns 1}}s{{end}}</span>
                     {{end}}
                 </div>
                 {{if .Transactions}}
@@ -136,6 +150,12 @@
                             {{if ne .RecievedTotal 0.0}}
                                 <td class="text-right">{{template "decimalParts" (float64AsDecimalParts .RecievedTotal false)}}</td>
                             {{else}}
+<<<<<<< HEAD
+=======
+                                {{if eq .SentTotal 0.0}}
+                                <td class="text-right">sstxcommitment</td>
+                                {{else}}
+>>>>>>> 3cf58e0... requested changes
                                 <td></td>
                             {{end}}
                             {{if ne .SentTotal 0.0}}
@@ -181,7 +201,7 @@
                 {{if lt .NumFundingTxns .KnownFundingTxns}}
                 {{if not .Fullmode}}
                 <div>
-                    *1000 is the upper limit for total number of transactions shown
+                    *Limit of 1000 transactions shown in lite mode.
                 </div>
                 {{end}}
                 <div

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -81,12 +81,12 @@
                         {{end}}
                     </tr>
                     {{if ne .NumUnconfirmed 0}}
-                    <tr>
-                        <td class="text-right pr-2">UNCONFIRMED</td>
-                        <td class="mono nowrap text-right">
-                            {{.NumUnconfirmed}} transaction{{if gt .NumUnconfirmed 0}}s{{end}}
-                        </td>
-                    </tr>
+                        <tr>
+                            <td class="text-right pr-2">UNCONFIRMED</td>
+                            <td class="mono nowrap text-right">
+                                {{.NumUnconfirmed}} transaction{{if gt .NumUnconfirmed 0}}s{{end}}
+                            </td>
+                        </tr>
                     {{end}}
                            
                     {{end}}
@@ -154,6 +154,7 @@
                                 <td class="text-right">sstxcommitment</td>
                                 {{else}}
                                 <td></td>
+                                {{end}}
                             {{end}}
                             {{if ne .SentTotal 0.0}}
                                 {{if lt 0.0 .SentTotal}}
@@ -192,7 +193,7 @@
                             No transactions found for this address.
                         </td>
                     </tr>
-            </table>
+                </table>
                 {{end}}
 
                 {{if lt .NumFundingTxns .KnownFundingTxns}}

--- a/views/address.tmpl
+++ b/views/address.tmpl
@@ -91,7 +91,9 @@
                         <span class="fs12 nowrap text-right"> {{intComma (add .Offset 1)}} &mdash; {{intComma (add .Offset .NumFundingTxns)}} of {{intComma .KnownFundingTxns}} funding transactions
                         {{else}}
                         <span class="fs12 nowrap text-right"> {{intComma (add .Offset 1)}} &mdash; {{intComma (add .Offset .NumTransactions)}} of {{intComma .KnownTransactions}} transactions
+                            {{if ge .KnownTransactions .MaxLimit}}
                             <sup>*</sup>
+                            {{end}}
                         {{end}}
                         </span>
                         <nav aria-label="address transactions navigation" data-limit="{{.Limit}}" class="ml-2">
@@ -187,7 +189,7 @@
                 </table>
                 {{end}}
 
-                {{if lt .NumTransactions .KnownTransactions}}
+                {{if ge .KnownTransactions .MaxLimit}}
                 {{if not .Fullmode}}
                 <div>
                     *Limit of 1000 transactions shown in lite mode.


### PR DESCRIPTION
sstx transactions appear in address without a credit or debit into the address, to show this types of transactions we are displaying 'sstxcommitment' in the credit column of these transactions for visibility. Also if the transactions exceed the maximum number of transactions the totals at the top become very inaccurate, to fixed this it is replaced with unavailable.