### PR TITLE
websocket: do not run unregister client asynchronously

### DIFF
--- a/explorer/websocket.go
+++ b/explorer/websocket.go
@@ -137,7 +137,7 @@ func (wsh *WebsocketHub) run() {
 				select {
 				case *client <- hubSignal:
 				default:
-					go wsh.unregisterClient(client)
+					wsh.unregisterClient(client)
 				}
 			}
 		case c := <-wsh.Register:


### PR DESCRIPTION
keep calls to register/unregister synchronous and in the main run loop since it's not thread safe