### PR TITLE
fix failure to decode testnet2 dev address

### DIFF
--- a/db/dbtypes/extraction.go
+++ b/db/dbtypes/extraction.go
@@ -12,6 +12,27 @@ import (
 	"github.com/decred/dcrd/wire"
 )
 
+// DevSubsidyAddress returns the development subsidy address for the specified
+// network.
+func DevSubsidyAddress(params *chaincfg.Params) (string, error) {
+	var devSubsidyAddress string
+	var err error
+	switch params.Name {
+	case "testnet2":
+		// TestNet2 uses an invalid organization PkScript
+		devSubsidyAddress = "TccTkqj8wFqrUemmHMRSx8SYEueQYLmuuFk"
+	default:
+		_, devSubsidyAddresses, _, err0 := txscript.ExtractPkScriptAddrs(
+			params.OrganizationPkScriptVersion, params.OrganizationPkScript, params)
+		if err0 != nil || len(devSubsidyAddresses) != 1 {
+			err = fmt.Errorf("failed to decode dev subsidy address: %v", err0)
+		} else {
+			devSubsidyAddress = devSubsidyAddresses[0].String()
+		}
+	}
+	return devSubsidyAddress, err
+}
+
 // ExtractBlockTransactions extracts transaction information from a
 // wire.MsgBlock and returns the processed information in slices of the dbtypes
 // Tx, Vout, and VinTxPropertyARRAY.

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -72,14 +72,21 @@ func NewChainDB(dbi *DBInfo, params *chaincfg.Params) (*ChainDB, error) {
 		strings.HasSuffix(err.Error(), "does not exist")) {
 		return nil, err
 	}
-	_, devSubsidyAddresses, _, err := txscript.ExtractPkScriptAddrs(
-		params.OrganizationPkScriptVersion, params.OrganizationPkScript, params)
+
 	var devSubsidyAddress string
-	if err != nil || len(devSubsidyAddresses) != 1 {
-		log.Warnf("Failed to decode dev subsidy address: %v", err)
+	if params.Name == "testnet2" {
+		devSubsidyAddress = "TccTkqj8wFqrUemmHMRSx8SYEueQYLmuuFk"
 	} else {
-		devSubsidyAddress = devSubsidyAddresses[0].String()
+		_, devSubsidyAddresses, _, err := txscript.ExtractPkScriptAddrs(
+			params.OrganizationPkScriptVersion, params.OrganizationPkScript, params)
+		if err != nil || len(devSubsidyAddresses) != 1 {
+
+			log.Warnf("Failed to decode dev subsidy address: %v", err)
+		} else {
+			devSubsidyAddress = devSubsidyAddresses[0].String()
+		}
 	}
+
 	return &ChainDB{
 		db:            db,
 		chainParams:   params,

--- a/db/dcrpg/pgblockchain.go
+++ b/db/dcrpg/pgblockchain.go
@@ -18,7 +18,6 @@ import (
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
-	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
 	humanize "github.com/dustin/go-humanize"
 )
@@ -73,18 +72,10 @@ func NewChainDB(dbi *DBInfo, params *chaincfg.Params) (*ChainDB, error) {
 		return nil, err
 	}
 
+	// Development subsidy address of the current network
 	var devSubsidyAddress string
-	if params.Name == "testnet2" {
-		devSubsidyAddress = "TccTkqj8wFqrUemmHMRSx8SYEueQYLmuuFk"
-	} else {
-		_, devSubsidyAddresses, _, err := txscript.ExtractPkScriptAddrs(
-			params.OrganizationPkScriptVersion, params.OrganizationPkScript, params)
-		if err != nil || len(devSubsidyAddresses) != 1 {
-
-			log.Warnf("Failed to decode dev subsidy address: %v", err)
-		} else {
-			devSubsidyAddress = devSubsidyAddresses[0].String()
-		}
+	if devSubsidyAddress, err = dbtypes.DevSubsidyAddress(params); err != nil {
+		log.Warnf("ChainDB.NewChainDB: %v", err)
 	}
 
 	return &ChainDB{

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -207,15 +207,19 @@ func New(dataSource explorerDataSourceLite, primaryDataSource explorerDataSource
 
 	params := exp.blockData.GetChainParams()
 	exp.ChainParams = params
-	_, devSubsidyAddresses, _, err := txscript.ExtractPkScriptAddrs(
-		params.OrganizationPkScriptVersion, params.OrganizationPkScript, params)
-	if err != nil || len(devSubsidyAddresses) != 1 {
-		log.Warnf("Failed to decode dev subsidy address: %v", err)
+	exp.ExtraInfo = new(HomeInfo)
+	if params.Name == "testnet2" {
+		exp.ExtraInfo.DevAddress = "TccTkqj8wFqrUemmHMRSx8SYEueQYLmuuFk"
 	} else {
-		exp.ExtraInfo = &HomeInfo{
-			DevAddress: devSubsidyAddresses[0].String(),
+		_, devSubsidyAddresses, _, err := txscript.ExtractPkScriptAddrs(
+			params.OrganizationPkScriptVersion, params.OrganizationPkScript, params)
+		if err != nil || len(devSubsidyAddresses) != 1 {
+			log.Warnf("Failed to decode dev subsidy address: %v", err)
+		} else {
+			exp.ExtraInfo.DevAddress = devSubsidyAddresses[0].String()
 		}
 	}
+
 	exp.templateFiles = make(map[string]string)
 	exp.templateFiles["home"] = filepath.Join("views", "home.tmpl")
 	exp.templateFiles["explorer"] = filepath.Join("views", "explorer.tmpl")


### PR DESCRIPTION
The testnet2 dev address cannot be decoded from the org pkscript because a bogus public key script is hard coded by dcrd