### PR TITLE
improve fresh start error handling and logging

### DIFF
--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -263,8 +263,9 @@ func (db *DB) GetBlockSummaryHeight() (int64, error) {
 		}
 		if err == sql.ErrNoRows {
 			log.Warn("Block summary DB is empty.")
+		} else {
+			db.dbSummaryHeight = height
 		}
-		db.dbSummaryHeight = height
 	}
 	return db.dbSummaryHeight, nil
 }

--- a/db/dcrsqlite/sqlite.go
+++ b/db/dcrsqlite/sqlite.go
@@ -63,7 +63,7 @@ type DB struct {
 // NewDB creates a new DB instance with pre-generated sql statements from an
 // existing sql.DB. Use InitDB to create a new DB without having a sql.DB.
 // TODO: if this db exists, figure out best heights
-func NewDB(db *sql.DB) *DB {
+func NewDB(db *sql.DB) (*DB, error) {
 	d := DB{
 		DB:                db,
 		dbSummaryHeight:   -1,
@@ -115,10 +115,15 @@ func NewDB(db *sql.DB) *DB {
         ) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `, TableNameStakeInfo)
 
-	d.dbSummaryHeight = d.GetBlockSummaryHeight()
-	d.dbStakeInfoHeight = d.GetStakeInfoHeight()
+	var err error
+	if d.dbSummaryHeight, err = d.GetBlockSummaryHeight(); err != nil {
+		return nil, err
+	}
+	if d.dbStakeInfoHeight, err = d.GetStakeInfoHeight(); err != nil {
+		return nil, err
+	}
 
-	return &d
+	return &d, nil
 }
 
 // InitDB creates a new DB instance from a DBInfo containing the name of the
@@ -170,8 +175,10 @@ func InitDB(dbInfo *DBInfo) (*DB, error) {
 		return nil, err
 	}
 
-	err = db.Ping()
-	return NewDB(db), err
+	if err = db.Ping(); err != nil {
+		return nil, err
+	}
+	return NewDB(db)
 }
 
 // DBDataSaver models a DB with a channel to communicate new block height to the web interface
@@ -239,39 +246,47 @@ func (db *DB) GetBestBlockHash() string {
 
 // GetBestBlockHeight returns the height of the best block
 func (db *DB) GetBestBlockHeight() int64 {
-	return db.GetBlockSummaryHeight()
+	h, _ := db.GetBlockSummaryHeight()
+	return h
 }
 
 // GetBlockSummaryHeight returns the largest block height for which the database
 // can provide a block summary
-func (db *DB) GetBlockSummaryHeight() int64 {
+func (db *DB) GetBlockSummaryHeight() (int64, error) {
 	db.RLock()
 	defer db.RUnlock()
 	if db.dbSummaryHeight < 0 {
 		height, err := db.RetrieveBestBlockHeight()
-		if err != nil {
-			log.Errorf("RetrieveBestBlockHeight failed: %v", err)
-			return -1
+		// No rows returned is not considered an error
+		if err != nil && err != sql.ErrNoRows {
+			return -1, fmt.Errorf("RetrieveBestBlockHeight failed: %v", err)
+		}
+		if err == sql.ErrNoRows {
+			log.Warn("Block summary DB is empty.")
 		}
 		db.dbSummaryHeight = height
 	}
-	return db.dbSummaryHeight
+	return db.dbSummaryHeight, nil
 }
 
 // GetStakeInfoHeight returns the largest block height for which the database
 // can provide a stake info
-func (db *DB) GetStakeInfoHeight() int64 {
+func (db *DB) GetStakeInfoHeight() (int64, error) {
 	db.RLock()
 	defer db.RUnlock()
 	if db.dbStakeInfoHeight < 0 {
 		si, err := db.RetrieveLatestStakeInfoExtended()
-		if err != nil || si == nil {
-			log.Errorf("RetrieveLatestStakeInfoExtended failed: %v", err)
-			return -1
+		// No rows returned is not considered an error
+		if err != nil && err != sql.ErrNoRows {
+			return -1, fmt.Errorf("RetrieveLatestStakeInfoExtended failed: %v", err)
+		}
+		if err == sql.ErrNoRows {
+			log.Warn("Stake info DB is empty.")
+			return -1, nil
 		}
 		db.dbStakeInfoHeight = int64(si.Feeinfo.Height)
 	}
-	return db.dbStakeInfoHeight
+	return db.dbStakeInfoHeight, nil
 }
 
 // RetrievePoolInfoRange returns an array of apitypes.TicketPoolInfo for block

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -255,7 +255,7 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) (int64, error) {
 		// TODO: winning tickets
 		//winningTickets := db.sDB.BestNode.Winners()
 
-		if (i-1)%rescanLogBlockChunk == 0 || i == startHeight {
+		if (i-1)%rescanLogBlockChunk == 0 && i-1 != startHeight || i == startHeight {
 			endRangeBlock := rescanLogBlockChunk * (1 + (i-1)/rescanLogBlockChunk)
 			if endRangeBlock > height {
 				endRangeBlock = height

--- a/db/dcrsqlite/sync.go
+++ b/db/dcrsqlite/sync.go
@@ -29,8 +29,13 @@ func (db *wiredDB) resyncDB(quit chan struct{}) error {
 	}
 
 	// Get DB's best block (for block summary and stake info tables)
-	bestBlockHeight := db.GetBlockSummaryHeight()
-	bestStakeHeight := db.GetStakeInfoHeight()
+	var bestBlockHeight, bestStakeHeight int64
+	if bestBlockHeight, err = db.GetBlockSummaryHeight(); err != nil {
+		return fmt.Errorf("GetBlockSummaryHeight failed: %v", err)
+	}
+	if bestStakeHeight, err = db.GetStakeInfoHeight(); err != nil {
+		return fmt.Errorf("GetStakeInfoHeight failed: %v", err)
+	}
 
 	log.Info("Current best block (chain server): ", height)
 	log.Info("Current best block (summary DB):   ", bestBlockHeight)
@@ -144,8 +149,13 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) (int64, error) {
 	}(time.Now(), &err)
 
 	// Get DB's best block (for block summary and stake info tables)
-	bestBlockHeight := db.GetBlockSummaryHeight()
-	bestStakeHeight := db.GetStakeInfoHeight()
+	var bestBlockHeight, bestStakeHeight int64
+	if bestBlockHeight, err = db.GetBlockSummaryHeight(); err != nil {
+		return -1, fmt.Errorf("GetBlockSummaryHeight failed: %v", err)
+	}
+	if bestStakeHeight, err = db.GetStakeInfoHeight(); err != nil {
+		return -1, fmt.Errorf("GetStakeInfoHeight failed: %v", err)
+	}
 
 	// Create a new database to store the accepted stake node data into.
 	if db.sDB == nil || db.sDB.BestNode == nil {
@@ -257,7 +267,9 @@ func (db *wiredDB) resyncDBWithPoolValue(quit chan struct{}) (int64, error) {
 		var tpi *apitypes.TicketPoolInfo
 		var found bool
 		if tpi, found = db.sDB.PoolInfo(*blockhash); !found {
-			log.Warnf("Unable to find block (%s) in pool info cache. Resync is malfunctioning!", blockhash.String())
+			if i != 0 {
+				log.Warnf("Unable to find block (%s) in pool info cache. Resync is malfunctioning!", blockhash.String())
+			}
 			ticketPoolInfo, sdbHeight := db.sDB.PoolInfoBest()
 			if int64(sdbHeight) != i {
 				log.Errorf("Collected block height %d != stake db height %d. Pool info "+

--- a/stakedb/stakedb.go
+++ b/stakedb/stakedb.go
@@ -420,7 +420,7 @@ func (db *StakeDatabase) Open() error {
 		db.StakeDB, err = database.Create(dbType, dbName, db.params.Net)
 		if err != nil {
 			// do not return nil interface, but interface of nil DB
-			return fmt.Errorf("error creating db: %v", err)
+			return fmt.Errorf("error creating database.DB: %v", err)
 		}
 		isFreshDB = true
 	}


### PR DESCRIPTION
Special handling for error message that should not be shown on fresh sync.
Add error return to several functions, including `dcrsqlite.NewDB`.
Fix returned height from `GetBlockSummaryHeight` when db is empty.
Do not log scanning progress for block 1 when just did genesis.