### PR TITLE
unbreak dev address balance after previous crash fix 

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -492,7 +492,7 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 
 	if !exp.liteMode {
 		_, devBalance, err := exp.explorerSource.AddressHistory(exp.ExtraInfo.DevAddress, 1, 0)
-		if err != nil && devBalance != nil {
+		if err == nil && devBalance != nil {
 			exp.ExtraInfo.DevFund = devBalance.TotalUnspent
 		} else {
 			log.Warnf("explorerUI.Store: %v", err)


### PR DESCRIPTION
the crash fix for testnet2 merged in PR https://github.com/dcrdata/dcrdata/pull/332/files broke the display of the dev address balance