### PR TITLE
Nil ptr check getexploreraddress

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -538,6 +539,8 @@ func (exp *explorerUI) Store(blockData *blockdata.BlockData, _ *wire.MsgBlock) e
 }
 
 func (exp *explorerUI) updateDevFundBalance() {
+	// yield processor to other goroutines
+	runtime.Gosched()
 	exp.NewBlockDataMtx.Lock()
 	defer exp.NewBlockDataMtx.Unlock()
 

--- a/explorer/explorerroutes.go
+++ b/explorer/explorerroutes.go
@@ -249,7 +249,12 @@ func (exp *explorerUI) AddressPage(w http.ResponseWriter, r *http.Request) {
 			address, limitN, offsetAddrOuts)
 		if errH != nil {
 			log.Errorf("Unable to get address %s history: %v", address, errH)
-			addrData := exp.blockData.GetExplorerAddress(address, limitN, offsetAddrOuts)
+			addrData = exp.blockData.GetExplorerAddress(address, limitN, offsetAddrOuts)
+			if addrData == nil {
+				log.Errorf("Unable to get address %s", address)
+				exp.ErrorPage(w, "Something went wrong...", "could not find that address", true)
+				return
+			}
 			confirmHeights := make([]int64, len(addrData.Transactions))
 			if addrData == nil {
 				exp.ErrorPage(w, "Something went wrong...", "could not find that address", false)


### PR DESCRIPTION
`GetExplorerAddress` ran w/o a nil pointer check in the AddressPage handler.

Also add a `Gosched()` in `updateDevFundBalance` since it's low priority and CPU intense.